### PR TITLE
wip: reduce serde_json feature to alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ lto = false
 codegen-units = 1
 debug = false
 opt-level = "z"
+strip = true

--- a/app-derive/Cargo.toml
+++ b/app-derive/Cargo.toml
@@ -13,7 +13,7 @@ syn = { version = "1.0", features = ["full", "extra-traits", "visit"] }
 proc-macro-error = { version = "1" }
 quote = "1.0"
 proc-macro2 = { version = "1.0.29" }
-serde_json = "1.0.79"
-serde = { version = "1.0.136", features = ["derive"] }
+serde_json = { version = "1.0.89", default-features=false, features = ["alloc"] } 
+serde = { version = "1.0.136",default-features=false, features = ["derive"] }
 bs58 = { version = "0.4.0", features = ["cb58"], git = "https://github.com/Zondax/bs58-rs", branch = "cb58" }
 convert_case = "0.6"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -60,6 +60,6 @@ time = { version = "0.3.15", features = ["formatting"]}
 k256 = { version = "0.9.6", features = ["ecdsa", "keccak256"] }
 rand = "0.8.5"
 insta = { version = "1", features = ["glob"] }
-serde_json = "1.0.85"
+serde_json = { version = "1.0.89", default-features=false, features = ["alloc"] } 
 itertools = "0.10.4"
 proptest = "1"

--- a/app/src/parser/coreth/native.rs
+++ b/app/src/parser/coreth/native.rs
@@ -326,9 +326,9 @@ mod tests {
         use crate::parser::snapshots_common::{with_leaked, ReducedPage};
 
         insta::glob!("eth_testvectors/*.json", |path| {
-            let file = std::fs::File::open(path)
+            let data = std::fs::read_to_string(path)
                 .unwrap_or_else(|e| panic!("Unable to open file {:?}: {:?}", path, e));
-            let input: Vec<u8> = serde_json::from_reader(file)
+            let input: Vec<u8> = serde_json::from_str(&data)
                 .unwrap_or_else(|e| panic!("Unable to read file {:?} as json: {:?}", path, e));
 
             let test = |data| {

--- a/app/src/parser/transactions.rs
+++ b/app/src/parser/transactions.rs
@@ -555,9 +555,9 @@ mod tests {
         use crate::parser::snapshots_common::{with_leaked, ReducedPage};
 
         insta::glob!("testvectors/*.json", |path| {
-            let file = std::fs::File::open(path)
+            let data = std::fs::read_to_string(path)
                 .unwrap_or_else(|e| panic!("Unable to open file {:?}: {:?}", path, e));
-            let input: Vec<u8> = serde_json::from_reader(file)
+            let input: Vec<u8> = serde_json::from_str(&data)
                 .unwrap_or_else(|e| panic!("Unable to read file {:?} as json: {:?}", path, e));
 
             let test = |data| {


### PR DESCRIPTION
experimental:

This PR replaced `serde_json::from_reader` allowing a drop of `std` feature and instead using  `alloc` but no space savings was found on binary.

Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>