### PR TITLE
Return address from device

### DIFF
--- a/app/src/integration_tests/mod.rs
+++ b/app/src/integration_tests/mod.rs
@@ -26,7 +26,7 @@ pub(self) mod prelude {
     pub use std::prelude::v1::*;
 
     pub(super) use crate::{
-        constants::{self, ApduError, CLA, CLA_ETH},
+        constants::{self, chain_alias_lookup, ApduError, CLA, CLA_ETH},
         crypto, rs_handle_apdu, PacketType,
     };
     pub use std::convert::TryInto;

--- a/app/src/integration_tests/public_key.rs
+++ b/app/src/integration_tests/public_key.rs
@@ -17,6 +17,27 @@ use super::prelude::*;
 
 use constants::INS_GET_PUBLIC_KEY as INS;
 
+fn addr_len(hrp: Option<&[u8]>, chain_id: Option<&[u8]>) -> usize {
+    use crate::handlers::public_key::{AddrUI, GetPublicKey};
+    use bolos::{bech32, hash::Ripemd160};
+
+    let chain_id = chain_id.unwrap_or(GetPublicKey::DEFAULT_CHAIN_ID);
+    let chain_id_len =
+        match chain_alias_lookup(chain_id.try_into().expect("chain id to be 32 bytes long")) {
+            Ok(alias) => alias.len(),
+            //not found, so needs to be cb58 encoded
+            Err(_) => AddrUI::MAX_CHAIN_CB58_LEN,
+        };
+
+    //chain id + '-' separator + bech32 address
+    chain_id_len
+        + 1
+        + bech32::estimate_size(
+            hrp.unwrap_or(GetPublicKey::DEFAULT_HRP).len(),
+            Ripemd160::DIGEST_LEN,
+        )
+}
+
 #[test]
 fn public_key() {
     let mut flags = 0u32;
@@ -31,8 +52,8 @@ fn public_key() {
     assert_error_code!(tx, out, ApduError::Success);
 
     let pk_len = out[0] as usize;
-    //secp256k1 pubkey and 20 bytes for hash + 2 for response code
-    assert_eq!(tx as usize, 1 + pk_len + 20 + 2);
+    //secp256k1 pubkey and 20 bytes for hash + address + 2 for response code
+    assert_eq!(tx as usize, 1 + pk_len + 20 + addr_len(None, None) + 2);
 }
 
 #[test]
@@ -42,15 +63,17 @@ fn public_key_with_hrp() {
     let rx = 5;
     let mut buffer = [0u8; 260];
 
+    let hrp = b"address";
+
     buffer[..3].copy_from_slice(&[CLA, INS, 0]);
-    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(b"address"), Some(&[]));
+    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(hrp), Some(&[]));
 
     let out = handle_apdu(&mut flags, &mut tx, rx, &mut buffer);
     assert_error_code!(tx, out, ApduError::Success);
 
     let pk_len = out[0] as usize;
-    //secp256k1 pubkey and 20 bytes for hash + 2 for response code
-    assert_eq!(tx as usize, 1 + pk_len + 20 + 2);
+    //secp256k1 pubkey and 20 bytes for hash + address + 2 for response code
+    assert_eq!(tx as usize, 1 + pk_len + 20 + addr_len(Some(hrp), None) + 2);
 }
 
 #[test]
@@ -61,20 +84,17 @@ fn public_key_with_too_long_hrp() {
     let rx = 5;
     let mut buffer = [0u8; 260];
 
+    let hrp = b"averylonghrpmaybetoolongeven";
+
     buffer[..3].copy_from_slice(&[CLA, INS, 0]);
-    prepare_buffer::<4>(
-        &mut buffer,
-        &[44, 9000, 0, 0],
-        Some(b"averylonghrpmaybetoolongeven"),
-        Some(&[]),
-    );
+    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(hrp), Some(&[]));
 
     let out = handle_apdu(&mut flags, &mut tx, rx, &mut buffer);
     assert_error_code!(tx, out, ApduError::Success);
 
     let pk_len = out[0] as usize;
-    //secp256k1 pubkey and 20 bytes for hash + 2 for response code
-    assert_eq!(tx as usize, 1 + pk_len + 20 + 2);
+    //secp256k1 pubkey and 20 bytes for hash + addres + 2 for response code
+    assert_eq!(tx as usize, 1 + pk_len + 20 + addr_len(Some(hrp), None) + 2);
 }
 
 #[test]
@@ -84,20 +104,17 @@ fn public_key_with_long_hrp() {
     let rx = 5;
     let mut buffer = [0u8; 260];
 
+    let hrp = b"exactly24characterlong!";
+
     buffer[..3].copy_from_slice(&[CLA, INS, 0]);
-    prepare_buffer::<4>(
-        &mut buffer,
-        &[44, 9000, 0, 0],
-        Some(b"exactly24charactherlong!"),
-        Some(&[]),
-    );
+    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(hrp), Some(&[]));
 
     let out = handle_apdu(&mut flags, &mut tx, rx, &mut buffer);
     assert_error_code!(tx, out, ApduError::Success);
 
     let pk_len = out[0] as usize;
-    //secp256k1 pubkey and 20 bytes for hash + 2 for response code
-    assert_eq!(tx as usize, 1 + pk_len + 20 + 2);
+    //secp256k1 pubkey and 20 bytes for hash + addr + 2 for response code
+    assert_eq!(tx as usize, 1 + pk_len + 20 + addr_len(Some(hrp), None) + 2);
 }
 
 #[test]
@@ -107,15 +124,20 @@ fn public_key_with_chainid() {
     let rx = 5;
     let mut buffer = [0u8; 260];
 
+    let chain_id = [42u8; 32];
+
     buffer[..3].copy_from_slice(&[CLA, INS, 0]);
-    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(&[]), Some(&[42; 32]));
+    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(&[]), Some(&chain_id));
 
     let out = handle_apdu(&mut flags, &mut tx, rx, &mut buffer);
     assert_error_code!(tx, out, ApduError::Success);
 
     let pk_len = out[0] as usize;
-    //secp256k1 pubkey and 20 bytes for hash + 2 for response code
-    assert_eq!(tx as usize, 1 + pk_len + 20 + 2);
+    //secp256k1 pubkey and 20 bytes for hash + addr + 2 for response code
+    assert_eq!(
+        tx as usize,
+        1 + pk_len + 20 + addr_len(None, Some(&chain_id)) + 2
+    );
 }
 
 #[test]
@@ -126,13 +148,18 @@ fn public_key_with_bad_chainid() {
     let rx = 5;
     let mut buffer = [0u8; 260];
 
+    let chain_id = [42u8; 10];
+
     buffer[..3].copy_from_slice(&[CLA, INS, 0]);
-    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(&[]), Some(&[42; 10]));
+    prepare_buffer::<4>(&mut buffer, &[44, 9000, 0, 0], Some(&[]), Some(&chain_id));
 
     let out = handle_apdu(&mut flags, &mut tx, rx, &mut buffer);
     assert_error_code!(tx, out, ApduError::Success);
 
     let pk_len = out[0] as usize;
-    //secp256k1 pubkey and 20 bytes for hash + 2 for response code
-    assert_eq!(tx as usize, 1 + pk_len + 20 + 2);
+    //secp256k1 pubkey and 20 bytes for hash + addr + 2 for response code
+    assert_eq!(
+        tx as usize,
+        1 + pk_len + 20 + addr_len(None, Some(&chain_id)) + 2
+    );
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -37,7 +37,7 @@ mod utils;
 use utils::ApduPanic;
 
 #[cfg(test)]
-use {handlers::ZPacketType as PacketType, parser::Transaction};
+use {handlers::ZPacketType as PacketType};
 mod crypto;
 
 cfg_if::cfg_if! {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -37,7 +37,7 @@ mod utils;
 use utils::ApduPanic;
 
 #[cfg(test)]
-use {handlers::ZPacketType as PacketType};
+use handlers::ZPacketType as PacketType;
 mod crypto;
 
 cfg_if::cfg_if! {

--- a/docs/APDUSPEC.md
+++ b/docs/APDUSPEC.md
@@ -125,6 +125,7 @@ If the ChainIDLen is 0, then the default ChainID of 32 zero bytes (P-Chain's)
 | PK_LEN    | byte (1)  | Bytes in PKEY    |                          |
 | PKEY      | byte (??) | Public key bytes | Compressed public key    |
 | PKEY_HASH | byte (20) | Public key hash  | Ripemd160(Sha256(PKEY))  |
+| ADDR      | byte (??) | Address          | CB58 encoded address     |
 | SW1-SW2   | byte (2)  | Return code      | see list of return codes |
 
 ### INS_GET_EXTENDED_PUBLIC_KEY

--- a/go/avalanche_test.go
+++ b/go/avalanche_test.go
@@ -76,28 +76,38 @@ func Test_UserGetPublicKey(t *testing.T) {
 	chainID := ""
 	showAddress := false
 
-	publicKey, hash, err := userApp.GetPubKey(path, showAddress, hrp, chainID)
+	addr, err := userApp.GetPubKey(path, showAddress, hrp, chainID)
 	if err != nil {
 		t.Fatalf("Detected error, err: %s\n", err.Error())
 	}
 
-	assert.Equal(t, 33, len(publicKey),
-		"Public key has wrong length: %x, expected length: %x\n", publicKey, 66)
-	fmt.Printf("PUBLIC KEY: %x\n", publicKey)
+	assert.Equal(t, 33, len(addr.publicKey),
+		"Public key has wrong length: %x, expected length: %x\n", addr.publicKey, 66)
+	fmt.Printf("PUBLIC KEY: %x\n", addr.publicKey)
 
-	assert.Equal(t, 20, len(hash),
-		"Public key has wrong length: %x, expected length: %x\n", hash, 40)
-	fmt.Printf("HASH: %x\n", hash)
+	assert.Equal(t, 20, len(addr.hash),
+		"Public key hash has wrong length: %x, expected length: %x\n", addr.hash, 40)
+	fmt.Printf("HASH: %x\n", addr.hash)
+
+	assert.Equal(t, len("P-avax1tlq4m9js4ckqvz9umfz7tjxna3yysm79r2jz8e"),
+		len(addr.address),
+		"Address has wrong length: %x, expected length: %x\n", addr.address, 43)
+	fmt.Printf("ADDRESS: %x\n", addr.address)
 
 	assert.Equal(t,
-		"03cb5a33c61595206294140c45efa8a817533e31aa05ea18343033a0732a677005",
-		hex.EncodeToString(publicKey),
+		"02c6f477ff8e7136de982f898f6bfe93136bbe8dada6c17d0cd369acce90036ac4",
+		hex.EncodeToString(addr.publicKey),
 		"Unexpected publicKey")
 
 	assert.Equal(t,
-		"62bcd95fccdfa668eb12be771a557d3595950799",
-		hex.EncodeToString(hash),
+		"5fc15d9650ae2c0608bcda45e5c8d3ec48486fc5",
+		hex.EncodeToString(addr.hash),
 		"Unexpected hash")
+
+	assert.Equal(t,
+		"P-avax1tlq4m9js4ckqvz9umfz7tjxna3yysm79r2jz8e",
+		addr.address,
+		"Unexpected address")
 }
 
 func Test_UserGetPublicKeyETH(t *testing.T) {
@@ -115,27 +125,28 @@ func Test_UserGetPublicKeyETH(t *testing.T) {
 	chainID := ""
 	showAddress := false
 
-	publicKey, hash, err := userApp.GetPubKey(pathETH, showAddress, hrp, chainID)
+	addr, err := userApp.GetPubKey(pathETH, showAddress, hrp, chainID)
 	if err != nil {
 		t.Fatalf("Detected error, err: %s\n", err.Error())
 	}
 
-	assert.Equal(t, 33, len(publicKey),
-		"Public key has wrong length: %x, expected length: %x\n", publicKey, 66)
-	fmt.Printf("PUBLIC KEY: %x\n", publicKey)
+	assert.Equal(t, 33, len(addr.publicKey),
+		"Public key has wrong length: %x, expected length: %x\n", addr.publicKey, 33)
+	fmt.Printf("PUBLIC KEY: %x\n", addr.publicKey)
 
-	assert.Equal(t, 20, len(hash),
-		"Public key has wrong length: %x, expected length: %x\n", hash, 40)
-	fmt.Printf("HASH: %x\n", hash)
+	assert.Equal(t, 20, len(addr.hash),
+		"Public key has wrong length: %x, expected length: %x\n", addr.hash, 20)
+	fmt.Printf("HASH: %x\n", addr.hash)
 
+	//FIXME: use proper test values
 	assert.Equal(t,
 		"03cb5a33c61595206294140c45efa8a817533e31aa05ea18343033a0732a677005",
-		hex.EncodeToString(publicKey),
+		hex.EncodeToString(addr.publicKey),
 		"Unexpected publicKey")
 
 	assert.Equal(t,
 		"62bcd95fccdfa668eb12be771a557d3595950799",
-		hex.EncodeToString(hash),
+		hex.EncodeToString(addr.hash),
 		"Unexpected hash")
 }
 
@@ -169,16 +180,18 @@ func Test_UserPK_HDPaths(t *testing.T) {
 	for i := uint32(0); i < 10; i++ {
 		path := fmt.Sprintf("m/44'/9000'/0'/0/%d", i)
 
-		publicKey, hash, err := userApp.GetPubKey(path, showAddress, hrp, chainID)
+		addr, err := userApp.GetPubKey(path, showAddress, hrp, chainID)
 		if err != nil {
 			t.Fatalf("Detected error, err: %s\n", err.Error())
 		}
+		publicKey := addr.publicKey
+		hash := addr.hash
 
 		assert.Equal(
 			t,
 			33,
 			len(publicKey),
-			"Public key has wrong length: %x, expected length: %x\n", publicKey, 65)
+			"Public key has wrong length: %x, expected length: %x\n", publicKey, 33)
 
 		assert.Equal(
 			t,
@@ -187,7 +200,7 @@ func Test_UserPK_HDPaths(t *testing.T) {
 			"Public key 44'/118'/0'/0/%d does not match\n", i)
 
 		assert.Equal(t, 20, len(hash),
-			"Public key has wrong length: %x, expected length: %x\n", hash, 40)
+			"Public key has wrong length: %x, expected length: %x\n", hash, 20)
 		fmt.Printf("HASH: %x\n", hash)
 	}
 }

--- a/go/types.go
+++ b/go/types.go
@@ -110,3 +110,9 @@ type ResponseSign struct {
 	Hash      []byte
 	Signature map[string][]byte
 }
+
+type ResponseAddr struct {
+	publicKey []byte
+	hash      []byte
+	address   string
+}

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -58,11 +58,17 @@ function processGetAddrResponse(response: Buffer) {
   //"advance" buffer
   partialResponse = partialResponse.slice(1 + PKLEN)
 
-  const hash = Buffer.from(partialResponse.slice(0, -2))
+  const hash = Buffer.from(partialResponse.slice(0, 20))
+
+  //"advance" buffer
+  partialResponse = partialResponse.slice(20)
+
+  const address = Buffer.from(partialResponse.subarray(0, -2)).toString()
 
   return {
     publicKey,
     hash,
+    address,
     returnCode,
     errorMessage: errorCodeToString(returnCode),
   }

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -6,6 +6,7 @@ export interface ResponseBase {
 export interface ResponseAddress extends ResponseBase {
   publicKey: Buffer
   hash: Buffer
+  address: string,
 }
 
 export interface ResponseXPub extends ResponseBase {

--- a/zemu/tests/addr.test.ts
+++ b/zemu/tests/addr.test.ts
@@ -20,7 +20,6 @@ import AvalancheApp from '@zondax/ledger-avalanche-app'
 import { encode as bs58_encode } from 'bs58'
 
 const EXPECTED_PUBLIC_KEY = '02c6f477ff8e7136de982f898f6bfe93136bbe8dada6c17d0cd369acce90036ac4';
-const EXPECTED_BECH32_PUBKEY = 'tlq4m9js4ckqvz9umfz7tjxna3yysm79r2jz8e'
 
 describe.each(models)('Standard [%s] - pubkey', function (m) {
   test(
@@ -40,7 +39,7 @@ describe.each(models)('Standard [%s] - pubkey', function (m) {
         expect(resp).toHaveProperty('hash')
         expect(resp).toHaveProperty('address')
         expect(resp.publicKey.toString('hex')).toEqual(EXPECTED_PUBLIC_KEY)
-        expect(resp.address).toEqual('P-avax1' + EXPECTED_BECH32_PUBKEY)
+        expect(resp.address).toEqual('P-avax1tlq4m9js4ckqvz9umfz7tjxna3yysm79r2jz8e')
       } finally {
         await sim.close()
       }
@@ -91,7 +90,7 @@ describe.each(models)('Standard [%s] - pubkey', function (m) {
         expect(resp).toHaveProperty('hash')
         expect(resp).toHaveProperty('address')
         expect(resp.address).toEqual('Ka3NKcnfs8d67EZYU5mbTCVY7Znnd2YQAYjbBfb4XmeWJuCGa'
-          + '-zemu1' + EXPECTED_BECH32_PUBKEY)
+          + '-zemu1tlq4m9js4ckqvz9umfz7tjxna3yysm79zy94y7')
       } finally {
         await sim.close()
       }

--- a/zemu/tests/addr.test.ts
+++ b/zemu/tests/addr.test.ts
@@ -80,13 +80,9 @@ describe.each(models)('Standard [%s] - pubkey', function (m) {
       try {
         await sim.start({ ...defaultOptions, model: m.name })
         const app = new AvalancheApp(sim.getTransport())
-        const respReq = app.getAddressAndPubKey(APP_DERIVATION, false,
+        const resp = await app.getAddressAndPubKey(APP_DERIVATION, false,
           "zemu", bs58_encode(Buffer.alloc(32, 42)))
 
-        await sim.waitUntilScreenIsNot(sim.getMainMenuSnapshot())
-        await sim.compareSnapshotsAndApprove('.', `${m.prefix.toLowerCase()}-zemu-addr`);
-
-        const resp = await respReq;
         console.log(resp, m.name)
 
         expect(resp.returnCode).toEqual(0x9000)

--- a/zemu/tests/addr.test.ts
+++ b/zemu/tests/addr.test.ts
@@ -20,6 +20,7 @@ import AvalancheApp from '@zondax/ledger-avalanche-app'
 import { encode as bs58_encode } from 'bs58'
 
 const EXPECTED_PUBLIC_KEY = '02c6f477ff8e7136de982f898f6bfe93136bbe8dada6c17d0cd369acce90036ac4';
+const EXPECTED_BECH32_PUBKEY = 'tlq4m9js4ckqvz9umfz7tjxna3yysm79r2jz8e'
 
 describe.each(models)('Standard [%s] - pubkey', function (m) {
   test(
@@ -37,7 +38,9 @@ describe.each(models)('Standard [%s] - pubkey', function (m) {
         expect(resp.errorMessage).toEqual('No errors')
         expect(resp).toHaveProperty('publicKey')
         expect(resp).toHaveProperty('hash')
+        expect(resp).toHaveProperty('address')
         expect(resp.publicKey.toString('hex')).toEqual(EXPECTED_PUBLIC_KEY)
+        expect(resp.address).toEqual('P-avax1' + EXPECTED_BECH32_PUBKEY)
       } finally {
         await sim.close()
       }
@@ -63,6 +66,36 @@ describe.each(models)('Standard [%s] - pubkey', function (m) {
         expect(resp.errorMessage).toEqual('No errors')
         expect(resp).toHaveProperty('publicKey')
         expect(resp).toHaveProperty('hash')
+        expect(resp).toHaveProperty('address')
+      } finally {
+        await sim.close()
+      }
+    },
+  );
+
+  test(
+    'get addr with custom hrp & chainID addr',
+    async function () {
+      const sim = new Zemu(m.path)
+      try {
+        await sim.start({ ...defaultOptions, model: m.name })
+        const app = new AvalancheApp(sim.getTransport())
+        const respReq = app.getAddressAndPubKey(APP_DERIVATION, false,
+          "zemu", bs58_encode(Buffer.alloc(32, 42)))
+
+        await sim.waitUntilScreenIsNot(sim.getMainMenuSnapshot())
+        await sim.compareSnapshotsAndApprove('.', `${m.prefix.toLowerCase()}-zemu-addr`);
+
+        const resp = await respReq;
+        console.log(resp, m.name)
+
+        expect(resp.returnCode).toEqual(0x9000)
+        expect(resp.errorMessage).toEqual('No errors')
+        expect(resp).toHaveProperty('publicKey')
+        expect(resp).toHaveProperty('hash')
+        expect(resp).toHaveProperty('address')
+        expect(resp.address).toEqual('Ka3NKcnfs8d67EZYU5mbTCVY7Znnd2YQAYjbBfb4XmeWJuCGa'
+          + '-zemu1' + EXPECTED_BECH32_PUBKEY)
       } finally {
         await sim.close()
       }
@@ -89,6 +122,7 @@ describe.each(models)('Standard [%s] - pubkey', function (m) {
         expect(resp.errorMessage).toEqual('No errors')
         expect(resp).toHaveProperty('publicKey')
         expect(resp).toHaveProperty('hash')
+        expect(resp).toHaveProperty('address')
       } finally {
         await sim.close()
       }


### PR DESCRIPTION
This PR changes the API of the `INS_GET_PUBKEY` instruction to return the address directly from the device. 

This is desirable so that programs interfacing with the app do not need to compute the address themselves, avoiding potential errors due to mismatching implementations.