### PR TITLE
Add special exception handler for IO errors

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -62,4 +62,4 @@ rand = "0.8.5"
 insta = { version = "1", features = ["glob"] }
 serde_json = "1.0.85"
 itertools = "0.10.4"
-proptest = "1"
+proptest = "1.0.*"

--- a/app/c/main.c
+++ b/app/c/main.c
@@ -132,6 +132,13 @@ int main(void) {
                 rs_handle_apdu(&flags, &tx, rx, G_io_apdu_buffer, IO_APDU_BUFFER_SIZE);
                 check_canary();
             }
+            CATCH(EXCEPTION_IO_RESET)
+            {
+            	// reset IO and UX before continuing
+                io_app_init();
+                view_idle_show(0, MENU_MAIN_APP_LINE2);
+                continue;
+            }
             CATCH_OTHER(e)
             {
                 if (!app_init_done) {


### PR DESCRIPTION
This PR fixes #112 by adding a special handler to catch IO exception such as when inappropriately disconnected the device transport