### PR TITLE
fix(eth_msg_sig): Compute the right v component

### DIFF
--- a/app/src/handlers/eth/personal_msg.rs
+++ b/app/src/handlers/eth/personal_msg.rs
@@ -215,7 +215,16 @@ impl Viewable for SignUI {
 
         //write signature as VRS
         //write V, which is the LSB of the firsts byte
-        out[tx] = flags.contains(ECCInfo::ParityOdd) as u8;
+        // follow app-ethereum
+        out[tx] = 27;
+        if flags.contains(ECCInfo::ParityOdd) {
+            out[tx] += 1;
+        }
+
+        if flags.contains(ECCInfo::XGTn) {
+            out[tx] += 2;
+        }
+
         tx += 1;
 
         //set to 0x30 for the conversion


### PR DESCRIPTION
The current v component is not set correctly, this PR addresses this issue following [reference](https://github.com/LedgerHQ/app-ethereum/blob/develop/src_features/signMessage/ui_common_signMessage.c#LL29C1-L35C6) implementation.