### PR TITLE
Disable ERC721 Approve test

### DIFF
--- a/zemu/tests/eth_legacy.test.ts
+++ b/zemu/tests/eth_legacy.test.ts
@@ -32,13 +32,18 @@ type NftInfo = {
   chain_id: number,
 }
 
+type Op = {
+  to?: string,
+  value?: string,
+  data?: string,
+}
 type TestData = {
   name: string,
-  op: Buffer,
-  nft_info: NftInfo | undefined,
-  chainId: number | undefined
+  op: Op,
+  nft_info?: NftInfo,
+  chainId?: number
 }
-const SIGN_TEST_DATA = [
+const SIGN_TEST_DATA: TestData[] = [
   {
     name: 'basic_transfer',
     op: {
@@ -84,21 +89,22 @@ const SIGN_TEST_DATA = [
     },
     chainId: 100,
   },
-  {
-    name: 'erc721_approve',
-    op: {
-      // this is not probably the contract address but lets use it
-      to: '62650ae5c5777d1660cc17fcd4f48f6a66b9a4c2',
-      value: '0',
-      data: '095ea7b30000000000000000000000005f658a6d1928c39b286b48192fea8d46d87ad07700000000000000000000000000000000000000000000000000000000000f4240',
-    },
-    chainId: 43114,
-    nft_info: {
-      token_address: '62650ae5c5777d1660cc17fcd4f48f6a66b9a4c2',
-      token_name: 'Unknown',
-      chain_id: 43114,
-    },
-  },
+  // TODO: fix after Ledger investigates the issue with the emulator
+  // {
+  //   name: 'erc721_approve',
+  //   op: {
+  //     // this is not probably the contract address but lets use it
+  //     to: '62650ae5c5777d1660cc17fcd4f48f6a66b9a4c2',
+  //     value: '0',
+  //     data: '095ea7b30000000000000000000000005f658a6d1928c39b286b48192fea8d46d87ad07700000000000000000000000000000000000000000000000000000000000f4240',
+  //   },
+  //   chainId: 43114,
+  //   nft_info: {
+  //     token_address: '62650ae5c5777d1660cc17fcd4f48f6a66b9a4c2',
+  //     token_name: 'Unknown',
+  //     chain_id: 43114,
+  //   },
+  // },
   {
     name: 'basic_transfer_no_eip155',
     op: {
@@ -115,7 +121,7 @@ const SIGN_TEST_DATA = [
   },
 ]
 
-const rawUnsignedLegacyTransaction = (params: any, chainId: number | undefined) => {
+const rawUnsignedLegacyTransaction = (params: Op, chainId?: number) => {
 
   const txParams = {
     nonce: '0x00',


### PR DESCRIPTION
This test has been problematic for a while now since the emulator crashes with this specific payload.
The issue lies outside the app and Ledger has already been informed, we are currently waiting on their investigation & fix.

We have tested this transaction on real devices and it works as intended. Additionally, investigating with GDB found the issue to be outside the scope of the app and is indeed reproducible with other apps as well (tested with only one other app).