### PR TITLE
Fix/audit 1

### DIFF
--- a/app/src/handlers/avax/message.rs
+++ b/app/src/handlers/avax/message.rs
@@ -91,7 +91,7 @@ pub(crate) struct SignUI {
 
 impl Viewable for SignUI {
     fn num_items(&mut self) -> Result<u8, ViewError> {
-        Ok(self.msg.num_items() as _)
+        self.msg.num_items()
     }
 
     #[inline(never)]

--- a/app/src/handlers/avax/signing.rs
+++ b/app/src/handlers/avax/signing.rs
@@ -185,7 +185,7 @@ pub(crate) struct SignUI {
 
 impl Viewable for SignUI {
     fn num_items(&mut self) -> Result<u8, ViewError> {
-        Ok(self.transaction.num_items() as _)
+        self.transaction.num_items()
     }
 
     #[inline(never)]

--- a/app/src/handlers/dev/debug.rs
+++ b/app/src/handlers/dev/debug.rs
@@ -37,7 +37,7 @@ impl ApduHandler for Debug {
 
         let payload = apdu.payload().map_err(|_| Error::DataInvalid)?;
 
-        let zbuffer = unsafe { BUFFER.lock(Self)? };
+        let zbuffer = unsafe { BUFFER.lock(Self) };
         zbuffer
             .write(&[
                 apdu.cla(),

--- a/app/src/handlers/eth/personal_msg.rs
+++ b/app/src/handlers/eth/personal_msg.rs
@@ -175,7 +175,7 @@ pub(crate) struct SignUI {
 
 impl Viewable for SignUI {
     fn num_items(&mut self) -> Result<u8, ViewError> {
-        Ok(self.tx.num_items() as _)
+        self.tx.num_items()
     }
 
     #[inline(never)]

--- a/app/src/handlers/eth/signing.rs
+++ b/app/src/handlers/eth/signing.rs
@@ -207,7 +207,7 @@ pub(crate) struct SignUI {
 
 impl Viewable for SignUI {
     fn num_items(&mut self) -> Result<u8, ViewError> {
-        Ok(self.tx.num_items() as _)
+        self.tx.num_items()
     }
 
     #[inline(never)]

--- a/app/src/parser.rs
+++ b/app/src/parser.rs
@@ -82,7 +82,7 @@ pub use coreth::{data::ERC721Info, nft_info::NftInfo};
 /// so that all the different OperationTypes or other items can handle their own UI
 pub trait DisplayableItem {
     /// Returns the number of items to display
-    fn num_items(&self) -> usize;
+    fn num_items(&self) -> Result<u8, ViewError>;
 
     /// This is invoked when a given page is to be displayed
     ///

--- a/app/src/parser/address.rs
+++ b/app/src/parser/address.rs
@@ -90,8 +90,8 @@ impl<'b> FromBytes<'b> for Address<'b> {
 }
 
 impl<'a> DisplayableItem for Address<'a> {
-    fn num_items(&self) -> usize {
-        1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        Ok(1)
     }
 
     #[inline(never)]

--- a/app/src/parser/asset_id.rs
+++ b/app/src/parser/asset_id.rs
@@ -56,8 +56,8 @@ impl<'b> AssetId<'b> {
 }
 
 impl<'a> DisplayableItem for AssetId<'a> {
-    fn num_items(&self) -> usize {
-        1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        Ok(1)
     }
 
     #[inline(never)]

--- a/app/src/parser/avm_output.rs
+++ b/app/src/parser/avm_output.rs
@@ -86,7 +86,7 @@ impl<'b> AvmOutput<'b> {
 }
 
 impl<'b> DisplayableItem for AvmOutput<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // the asset_id is not part of the summary we need from objects of this type,
         // but could give to higher level objects information to display such information.
         self.0.num_items()

--- a/app/src/parser/coreth/data.rs
+++ b/app/src/parser/coreth/data.rs
@@ -164,9 +164,9 @@ impl<'b> EthData<'b> {
 }
 
 impl<'b> DisplayableItem for EthData<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         match self {
-            Self::None => 0,
+            Self::None => Ok(0),
             Self::Deploy(d) => d.num_items(),
             Self::AssetCall(d) => d.num_items(),
             #[cfg(feature = "erc20")]

--- a/app/src/parser/coreth/data/asset_call.rs
+++ b/app/src/parser/coreth/data/asset_call.rs
@@ -105,9 +105,9 @@ impl<'b> AssetCall<'b> {
 }
 
 impl<'b> DisplayableItem for AssetCall<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // transfer/deposit, asset_id and address
-        1 + 1 + 1
+        Ok(1 + 1 + 1)
     }
 
     fn render_item(

--- a/app/src/parser/coreth/data/contract_call.rs
+++ b/app/src/parser/coreth/data/contract_call.rs
@@ -60,9 +60,9 @@ impl<'b> ContractCall<'b> {
 }
 
 impl<'b> DisplayableItem for ContractCall<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // data
-        1
+        Ok(1)
     }
 
     fn render_item(

--- a/app/src/parser/coreth/data/deploy.rs
+++ b/app/src/parser/coreth/data/deploy.rs
@@ -48,8 +48,8 @@ impl<'b> Deploy<'b> {
 }
 
 impl<'b> DisplayableItem for Deploy<'b> {
-    fn num_items(&self) -> usize {
-        1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        Ok(1)
     }
 
     fn render_item(

--- a/app/src/parser/coreth/data/erc20.rs
+++ b/app/src/parser/coreth/data/erc20.rs
@@ -329,12 +329,14 @@ impl<'b> ERC20<'b> {
 }
 
 impl<'b> DisplayableItem for ERC20<'b> {
-    fn num_items(&self) -> usize {
-        1 + match self {
+    fn num_items(&self) -> Result<u8, ViewError> {
+        let items = match self {
             ERC20::Transfer { .. } => 2,
             ERC20::TransferFrom { .. } => 3,
             ERC20::Approve { .. } => 2,
-        }
+        };
+
+        Ok(1 + items)
     }
 
     fn render_item(

--- a/app/src/parser/coreth/export_tx.rs
+++ b/app/src/parser/coreth/export_tx.rs
@@ -330,7 +330,7 @@ impl<'b> DisplayableItem for ExportTx<'b> {
         let new_item_n = item_n - 1;
 
         match new_item_n {
-            x @ 0.. if x < outputs_num_items as u8 => self.render_outputs(x, title, message, page),
+            x @ 0.. if x < outputs_num_items => self.render_outputs(x, title, message, page),
             x if x == outputs_num_items => {
                 let title_content = pic_str!(b"Fee");
                 title[..title_content.len()].copy_from_slice(title_content);

--- a/app/src/parser/coreth/inputs.rs
+++ b/app/src/parser/coreth/inputs.rs
@@ -20,6 +20,7 @@ use nom::number::complete::be_u64;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{Address, AssetId, DisplayableItem, FromBytes},
     utils::is_app_mode_expert,
@@ -82,16 +83,16 @@ impl<'b> FromBytes<'b> for EVMInput<'b> {
 }
 
 impl<'b> DisplayableItem for EVMInput<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // expert: address, nonce
         let expert = if is_app_mode_expert() {
-            self.address.num_items() + 1
+            self.address.num_items()? + 1
         } else {
             0
         };
 
         //type, asset id, amount
-        1 + self.asset_id.num_items() + 1 + expert
+        checked_add!(ViewError::Unknown, 2u8, expert, self.asset_id.num_items()?)
     }
 
     fn render_item(

--- a/app/src/parser/coreth/native.rs
+++ b/app/src/parser/coreth/native.rs
@@ -259,7 +259,7 @@ impl<'b> FromBytes<'b> for EthTransaction<'b> {
 }
 
 impl<'b> DisplayableItem for EthTransaction<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         match self {
             Self::Legacy(t) => t.num_items(),
             Self::Eip1559(t) => t.num_items(),
@@ -292,7 +292,7 @@ mod tests {
 
     impl Viewable for EthTransaction<'static> {
         fn num_items(&mut self) -> Result<u8, zemu_sys::ViewError> {
-            Ok(DisplayableItem::num_items(&*self) as u8)
+            DisplayableItem::num_items(&*self)
         }
 
         fn render_item(

--- a/app/src/parser/coreth/native/eip2930.rs
+++ b/app/src/parser/coreth/native/eip2930.rs
@@ -87,7 +87,7 @@ impl<'b> FromBytes<'b> for Eip2930<'b> {
 }
 
 impl<'b> DisplayableItem for Eip2930<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         self.base.num_items()
     }
 

--- a/app/src/parser/coreth/native/legacy.rs
+++ b/app/src/parser/coreth/native/legacy.rs
@@ -113,7 +113,7 @@ impl<'b> FromBytes<'b> for Legacy<'b> {
 }
 
 impl<'b> DisplayableItem for Legacy<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         self.base.num_items()
     }
 

--- a/app/src/parser/coreth/native/sign_msg.rs
+++ b/app/src/parser/coreth/native/sign_msg.rs
@@ -17,6 +17,7 @@
 use core::{mem::MaybeUninit, ptr::addr_of_mut};
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{DisplayableItem, FromBytes, Message},
 };
@@ -52,8 +53,8 @@ impl<'b> FromBytes<'b> for PersonalMsg<'b> {
 }
 
 impl<'b> DisplayableItem for PersonalMsg<'b> {
-    fn num_items(&self) -> usize {
-        1 + self.0.num_items()
+    fn num_items(&self) -> Result<u8, ViewError> {
+        checked_add!(ViewError::Unknown, 1u8, self.0.num_items()?)
     }
 
     fn render_item(

--- a/app/src/parser/coreth/outputs.rs
+++ b/app/src/parser/coreth/outputs.rs
@@ -20,6 +20,7 @@ use core::{mem::MaybeUninit, ptr::addr_of_mut};
 use nom::number::complete::{be_u32, be_u64};
 use zemu_sys::ViewError;
 
+use crate::checked_add;
 use crate::{
     handlers::handle_ui_message,
     parser::{
@@ -78,7 +79,7 @@ impl<'b> EOutput<'b> {
 }
 
 impl<'b> DisplayableItem for EOutput<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         self.0.num_items()
     }
 
@@ -148,9 +149,9 @@ impl<'b> FromBytes<'b> for EVMOutput<'b> {
 }
 
 impl<'b> DisplayableItem for EVMOutput<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // amount, address
-        1 + self.address.num_items()
+        checked_add!(ViewError::Unknown, 1u8, self.address.num_items()?)
     }
 
     fn render_item(

--- a/app/src/parser/defer.rs
+++ b/app/src/parser/defer.rs
@@ -86,7 +86,7 @@ where
     Obj: DisplayableItem + FromBytes<'b>,
 {
     #[inline(always)]
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         self.read().num_items()
     }
 

--- a/app/src/parser/inputs.rs
+++ b/app/src/parser/inputs.rs
@@ -26,6 +26,7 @@ use nom::{
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{error::ParserError, AssetId, DisplayableItem, FromBytes},
     utils::hex_encode,
@@ -109,8 +110,13 @@ impl<'b> FromBytes<'b> for TransferableInput<'b> {
 }
 
 impl<'b> DisplayableItem for TransferableInput<'b> {
-    fn num_items(&self) -> usize {
-        1 + 1 + self.asset_id.num_items() + self.input.num_items()
+    fn num_items(&self) -> Result<u8, ViewError> {
+        checked_add!(
+            ViewError::Unknown,
+            2u8,
+            self.asset_id.num_items()?,
+            self.input.num_items()?
+        )
     }
 
     fn render_item(
@@ -148,7 +154,7 @@ impl<'b> DisplayableItem for TransferableInput<'b> {
 
             2 => self.asset_id.render_item(0, title, message, page),
 
-            x @ 3.. if (x as usize) < 3 + self.input.num_items() => {
+            x @ 3.. if x < 3 + self.input.num_items()? => {
                 let index = x - 3;
                 self.input.render_item(index, title, message, page)
             }
@@ -236,7 +242,7 @@ impl<'b> FromBytes<'b> for Input<'b> {
 }
 
 impl<'a> DisplayableItem for Input<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         match self {
             Self::SECPTransfer(t) => t.num_items(),
         }

--- a/app/src/parser/inputs/secp_transfer_input.rs
+++ b/app/src/parser/inputs/secp_transfer_input.rs
@@ -22,6 +22,7 @@ use nom::{
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{DisplayableItem, FromBytes, ParserError, U32_SIZE},
 };
@@ -77,9 +78,9 @@ impl<'b> FromBytes<'b> for SECPTransferInput<'b> {
 }
 
 impl<'a> DisplayableItem for SECPTransferInput<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // output-type, amount, indices
-        1 + 1 + self.address_indices.len()
+        checked_add!(ViewError::Unknown, 2u8, self.address_indices.len() as u8)
     }
 
     #[inline(never)]

--- a/app/src/parser/message.rs
+++ b/app/src/parser/message.rs
@@ -112,8 +112,8 @@ impl<'b> FromBytes<'b> for Message<'b> {
 }
 
 impl<'b> DisplayableItem for Message<'b> {
-    fn num_items(&self) -> usize {
-        1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        Ok(1)
     }
 
     fn render_item(
@@ -175,9 +175,10 @@ impl<'b> FromBytes<'b> for AvaxMessage<'b> {
 }
 
 impl<'b> DisplayableItem for AvaxMessage<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // Description + message
-        1 + self.data.num_items()
+        let items = self.data.num_items()?;
+        items.checked_add(1).ok_or(ViewError::Unknown)
     }
 
     fn render_item(

--- a/app/src/parser/node_id.rs
+++ b/app/src/parser/node_id.rs
@@ -62,8 +62,8 @@ impl<'b> FromBytes<'b> for NodeId<'b> {
 }
 
 impl<'b> DisplayableItem for NodeId<'b> {
-    fn num_items(&self) -> usize {
-        1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        Ok(1)
     }
 
     fn render_item(

--- a/app/src/parser/object_list.rs
+++ b/app/src/parser/object_list.rs
@@ -356,7 +356,10 @@ mod tests {
     #[test]
     fn object_list_iterator() {
         let (_, list) = ObjectList::<TransferableOutput<AvmOutput>>::new(DATA).unwrap();
-        let num_items: usize = list.iter().map(|output| output.num_items()).sum();
+        let num_items: usize = list
+            .iter()
+            .map(|output| output.num_items().expect("Overflow!") as usize)
+            .sum();
         // the iterator does not change the state of the
         // main list object, as we return just a copy
         assert_eq!(list.read, 0);

--- a/app/src/parser/operations/nft_mint_operation.rs
+++ b/app/src/parser/operations/nft_mint_operation.rs
@@ -76,7 +76,7 @@ impl<'b> FromBytes<'b> for NFTMintOperation<'b> {
 }
 
 impl<'a> DisplayableItem for NFTMintOperation<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         self.nft_output.num_items()
     }
 

--- a/app/src/parser/operations/nft_transfer_operation.rs
+++ b/app/src/parser/operations/nft_transfer_operation.rs
@@ -75,7 +75,7 @@ impl<'b> FromBytes<'b> for NFTTransferOperation<'b> {
 }
 
 impl<'b> DisplayableItem for NFTTransferOperation<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, zemu_sys::ViewError> {
         self.nft_transfer_output.num_items()
     }
 

--- a/app/src/parser/operations/secp_mint_operation.rs
+++ b/app/src/parser/operations/secp_mint_operation.rs
@@ -75,10 +75,12 @@ impl<'b> FromBytes<'b> for SECPMintOperation<'b> {
 }
 
 impl<'b> DisplayableItem for SECPMintOperation<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // operation description
         // and the transfer to the new mint-output owners
-        1 + self.transfer_output.num_items()
+        self.transfer_output
+            .num_items()
+            .and_then(|a| a.checked_add(1).ok_or(ViewError::Unknown))
     }
 
     fn render_item(

--- a/app/src/parser/outputs.rs
+++ b/app/src/parser/outputs.rs
@@ -118,7 +118,7 @@ impl<'b, O> DisplayableItem for TransferableOutput<'b, O>
 where
     O: FromBytes<'b> + DisplayableItem + Deref<Target = Output<'b>> + 'b,
 {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // the asset_id is not part of the summary we need from objects of this type,
         // but could give to higher level objects information to display such information.
         self.output.num_items()
@@ -296,7 +296,7 @@ impl<'b> Output<'b> {
 }
 
 impl<'a> DisplayableItem for Output<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         match self {
             Self::SECPTransfer(t) => t.num_items(),
             Self::SECPMint(m) => m.num_items(),

--- a/app/src/parser/outputs/nft_mint_output.rs
+++ b/app/src/parser/outputs/nft_mint_output.rs
@@ -122,7 +122,7 @@ impl<'a> DisplayableItem for NFTMintOutput<'a> {
         // directly since it offsets the pages by 1 if present
         let render_threshold_at = 2 + render_locktime as u8;
 
-        match item_n as u8 {
+        match item_n {
             0 => {
                 let title_content = pic_str!(b"Output");
                 title[..title_content.len()].copy_from_slice(title_content);

--- a/app/src/parser/outputs/nft_mint_output.rs
+++ b/app/src/parser/outputs/nft_mint_output.rs
@@ -22,6 +22,7 @@ use nom::{
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         u32_to_str, u64_to_str, Address, DisplayableItem, FromBytes, ParserError, ADDRESS_LEN,
@@ -92,11 +93,15 @@ impl<'b> FromBytes<'b> for NFTMintOutput<'b> {
 }
 
 impl<'a> DisplayableItem for NFTMintOutput<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // output-type, group_id, threshold and addresses
-        let items = 1 + 1 + 1 + self.addresses.len();
         // do not show locktime if it is 0
-        items + (self.locktime > 0) as usize
+        checked_add!(
+            ViewError::Unknown,
+            3u8,
+            self.addresses.len() as _,
+            (self.locktime > 0) as u8
+        )
     }
 
     #[inline(never)]
@@ -111,13 +116,13 @@ impl<'a> DisplayableItem for NFTMintOutput<'a> {
         use lexical_core::Number;
 
         let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];
-        let addr_item_n = self.num_items() - self.addresses.len();
+        let addr_item_n = self.num_items()? - self.addresses.len() as u8;
         let render_locktime = self.locktime > 0;
         // Gets the page at which this field is displayed, by summing the boolean
         // directly since it offsets the pages by 1 if present
-        let render_threshold_at = 2 + render_locktime as usize;
+        let render_threshold_at = 2 + render_locktime as u8;
 
-        match item_n as usize {
+        match item_n as u8 {
             0 => {
                 let title_content = pic_str!(b"Output");
                 title[..title_content.len()].copy_from_slice(title_content);
@@ -152,7 +157,7 @@ impl<'a> DisplayableItem for NFTMintOutput<'a> {
 
             x @ 3.. if x >= addr_item_n => {
                 let idx = x - addr_item_n;
-                if let Some(data) = self.addresses.get(idx) {
+                if let Some(data) = self.addresses.get(idx as usize) {
                     let mut addr = MaybeUninit::uninit();
                     Address::from_bytes_into(data, &mut addr).map_err(|_| ViewError::Unknown)?;
                     let addr = unsafe { addr.assume_init() };

--- a/app/src/parser/outputs/nft_transfer_output.rs
+++ b/app/src/parser/outputs/nft_transfer_output.rs
@@ -22,6 +22,7 @@ use nom::{
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{u32_to_str, Address, DisplayableItem, FromBytes, ParserError, ADDRESS_LEN},
     utils::hex_encode,
@@ -115,9 +116,9 @@ impl<'b> FromBytes<'b> for NFTTransferOutput<'b> {
 }
 
 impl<'a> DisplayableItem for NFTTransferOutput<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // group_id, payload and addresses
-        1 + 1 + self.num_addresses()
+        checked_add!(ViewError::Unknown, 2u8, self.num_addresses() as u8)
     }
 
     #[inline(never)]

--- a/app/src/parser/outputs/secp_mint_output.rs
+++ b/app/src/parser/outputs/secp_mint_output.rs
@@ -22,6 +22,7 @@ use nom::{
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{Address, DisplayableItem, FromBytes, ParserError, ADDRESS_LEN},
 };
@@ -87,11 +88,14 @@ impl<'b> FromBytes<'b> for SECPMintOutput<'b> {
 }
 
 impl<'a> DisplayableItem for SECPMintOutput<'a> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // output-type, threshold and addresses
-        let items = 1 + 1 + self.addresses.len();
-        // do not show locktime if it is 0
-        items + (self.locktime > 0) as usize
+        checked_add!(
+            ViewError::Unknown,
+            2u8,
+            self.addresses.len() as u8,
+            (self.locktime > 0) as u8
+        )
     }
 
     #[inline(never)]
@@ -106,9 +110,9 @@ impl<'a> DisplayableItem for SECPMintOutput<'a> {
         use lexical_core::{write as itoa, Number};
 
         let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];
-        let addr_item_n = self.num_items() - self.addresses.len();
+        let addr_item_n = self.num_items()? - self.addresses.len() as u8;
 
-        match item_n as usize {
+        match item_n {
             0 => {
                 let title_content = pic_str!(b"Output");
                 title[..title_content.len()].copy_from_slice(title_content);
@@ -135,7 +139,7 @@ impl<'a> DisplayableItem for SECPMintOutput<'a> {
 
             x @ 2.. if x >= addr_item_n => {
                 let idx = x - addr_item_n;
-                if let Some(data) = self.addresses.get(idx) {
+                if let Some(data) = self.addresses.get(idx as usize) {
                     let mut addr = MaybeUninit::uninit();
                     Address::from_bytes_into(data, &mut addr).map_err(|_| ViewError::Unknown)?;
                     let addr = unsafe { addr.assume_init() };

--- a/app/src/parser/proof_of_possession.rs
+++ b/app/src/parser/proof_of_possession.rs
@@ -119,11 +119,12 @@ impl<'b> FromBytes<'b> for BLSSigner<'b> {
 }
 
 impl<'b> DisplayableItem for BLSSigner<'b> {
-    fn num_items(&self) -> usize {
-        match &self {
+    fn num_items(&self) -> Result<u8, ViewError> {
+        let i = match &self {
             BLSSigner::EmptyProof => 0,
             BLSSigner::Proof(_) => 1,
-        }
+        };
+        Ok(i)
     }
 
     fn render_item(

--- a/app/src/parser/subnet_id.rs
+++ b/app/src/parser/subnet_id.rs
@@ -60,8 +60,8 @@ impl<'b> FromBytes<'b> for SubnetId<'b> {
 }
 
 impl<'b> DisplayableItem for SubnetId<'b> {
-    fn num_items(&self) -> usize {
-        1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        Ok(1)
     }
 
     fn render_item(

--- a/app/src/parser/transactions.rs
+++ b/app/src/parser/transactions.rs
@@ -326,7 +326,7 @@ impl<'b> Transaction<'b> {
 }
 
 impl<'b> DisplayableItem for Transaction<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, zemu_sys::ViewError> {
         match self {
             Self::XImport(tx) => tx.num_items(),
             Self::XExport(tx) => tx.num_items(),
@@ -411,7 +411,7 @@ mod tests {
     /// it's present inside the `mod test` block only
     impl Viewable for Transaction<'static> {
         fn num_items(&mut self) -> Result<u8, zemu_sys::ViewError> {
-            Ok(DisplayableItem::num_items(&*self) as u8)
+            DisplayableItem::num_items(&*self)
         }
 
         fn render_item(
@@ -446,13 +446,13 @@ mod tests {
 
         let mut tx = Transaction::new(&data).unwrap();
         // get number of items with all active outputs
-        let num_items = tx.num_items();
+        let num_items = tx.num_items().expect("Overflow?");
 
         // disable one output.
         tx.disable_output_if(&change_address);
 
         //get again the number of outputs
-        let num_items_hide = tx.num_items();
+        let num_items_hide = tx.num_items().expect("Overflows?");
 
         // ensure the number of items has changed
         // as there is now one output that is disable

--- a/app/src/parser/transactions/avm/create_asset.rs
+++ b/app/src/parser/transactions/avm/create_asset.rs
@@ -116,9 +116,9 @@ impl<'b> FromBytes<'b> for CreateAssetTx<'b> {
 }
 
 impl<'b> DisplayableItem for CreateAssetTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // description + asset_name + asset_symbol + denomination + fee
-        1 + 1 + 1 + 1 + 1
+        Ok(1 + 1 + 1 + 1 + 1)
     }
 
     fn render_item(

--- a/app/src/parser/transactions/avm/export_tx.rs
+++ b/app/src/parser/transactions/avm/export_tx.rs
@@ -79,10 +79,8 @@ impl<'b> DisplayableItem for AvmExportTx<'b> {
         let new_item_n = item_n - 1;
 
         match new_item_n {
-            x @ 0.. if x < outputs_num_items as u8 => {
-                self.0.render_outputs(x, title, message, page)
-            }
-            x if x == outputs_num_items as u8 => {
+            x @ 0.. if x < outputs_num_items => self.0.render_outputs(x, title, message, page),
+            x if x == outputs_num_items => {
                 let title_content = pic_str!(b"Fee(AVAX)");
                 title[..title_content.len()].copy_from_slice(title_content);
                 let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];

--- a/app/src/parser/transactions/avm/export_tx.rs
+++ b/app/src/parser/transactions/avm/export_tx.rs
@@ -19,6 +19,7 @@ use nom::bytes::complete::tag;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, AvmOutput, BaseExport, DisplayableItem, FromBytes, ParserError,
@@ -51,12 +52,12 @@ impl<'b> FromBytes<'b> for AvmExportTx<'b> {
 }
 
 impl<'b> DisplayableItem for AvmExportTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // only support SECP256k1 outputs
         // and to keep compatibility with the legacy app,
         // we show only 4 items for each output
         // chains info, amount, address and fee which is the sum of all inputs minus all outputs
-        1 + self.0.num_outputs_items() + 1
+        checked_add!(ViewError::Unknown, 2u8, self.0.num_outputs_items()?)
     }
 
     fn render_item(
@@ -74,7 +75,7 @@ impl<'b> DisplayableItem for AvmExportTx<'b> {
             return self.0.render_export_description(title, message, page);
         }
 
-        let outputs_num_items = self.0.num_outputs_items();
+        let outputs_num_items = self.0.num_outputs_items()?;
         let new_item_n = item_n - 1;
 
         match new_item_n {

--- a/app/src/parser/transactions/avm/import_tx.rs
+++ b/app/src/parser/transactions/avm/import_tx.rs
@@ -19,6 +19,7 @@ use nom::bytes::complete::tag;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, AvmOutput, BaseImport, DisplayableItem, FromBytes, ParserError,
@@ -64,13 +65,13 @@ impl<'b> AvmImportTx<'b> {
 }
 
 impl<'b> DisplayableItem for AvmImportTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // only support SECP256k1 outputs
         // and to keep compatibility with the legacy app,
         // we show only 4 items for each output
         // tx info, amount, address and fee which is the sum of all inputs minus all outputs
         // and the chain description
-        1 + self.0.num_input_items() + 1 + 1
+        checked_add!(ViewError::Unknown, 3u8, self.0.num_input_items()?)
     }
 
     fn render_item(
@@ -90,7 +91,7 @@ impl<'b> DisplayableItem for AvmImportTx<'b> {
             return handle_ui_message(&value_content[..], message, page);
         }
 
-        let inputs_num_items = self.0.num_input_items() as u8;
+        let inputs_num_items = self.0.num_input_items()?;
         let new_item_n = item_n - 1;
 
         match new_item_n {

--- a/app/src/parser/transactions/avm/operation_tx.rs
+++ b/app/src/parser/transactions/avm/operation_tx.rs
@@ -1,3 +1,4 @@
+use crate::checked_add;
 /*******************************************************************************
 *   (c) 2021 Zondax GmbH
 *
@@ -51,12 +52,24 @@ impl<'b> OperationTx<'b> {
         Ok(fee)
     }
 
-    fn operation_items(&self) -> usize {
+    fn operation_items(&self) -> Result<u8, ViewError> {
         let mut num_items = 0;
+
+        let mut err: Option<ViewError> = None;
         self.operations.iterate_with(|op| {
-            num_items += op.num_items();
+            match op
+                .num_items()
+                .and_then(|a| a.checked_add(num_items).ok_or(ViewError::Unknown))
+            {
+                Ok(i) => num_items = i,
+                Err(_) => err = Some(ViewError::Unknown),
+            }
         });
-        num_items
+
+        if err.is_some() {
+            return Err(ViewError::Unknown);
+        }
+        Ok(num_items)
     }
 
     pub fn op_with_item(&'b self, item_n: u8) -> Result<(TransferableOp, u8), ParserError> {
@@ -65,7 +78,10 @@ impl<'b> OperationTx<'b> {
         // gets the operation that contains item_n
         // and its corresponding index
         let filter = |o: &TransferableOp<'b>| -> bool {
-            let n = o.num_items();
+            let Ok(n) = o.num_items() else {
+                return false;
+            };
+
             for index in 0..n {
                 obj_item_n = index;
                 if count == item_n as usize {
@@ -101,7 +117,7 @@ impl<'b> OperationTx<'b> {
         // this is a secp_transfer so it contain
         // 1 item amount
         // x items which is one item for each address
-        let num_inner_items = obj.num_items() as _;
+        let num_inner_items = obj.num_items()?;
 
         match idx {
             0 => {
@@ -179,9 +195,12 @@ impl<'b> FromBytes<'b> for OperationTx<'b> {
 }
 
 impl<'b> DisplayableItem for OperationTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // description +
-        1 + self.base_tx.base_outputs_num_items() + self.operation_items() + 1 // fee
+        let base = self.base_tx.base_outputs_num_items()?;
+        let operation = self.operation_items()?;
+
+        checked_add!(ViewError::Unknown, 2u8, base, operation)
     }
 
     fn render_item(
@@ -203,16 +222,16 @@ impl<'b> DisplayableItem for OperationTx<'b> {
 
         let item_n = item_n - 1;
 
-        let base_items = self.base_tx.base_outputs_num_items() as u8;
+        let base_items = self.base_tx.base_outputs_num_items()?;
 
         match item_n {
             x @ 0.. if x < base_items => self.render_outputs(item_n, title, message, page),
-            x if x >= base_items && x < self.num_items() as u8 - 2 => {
+            x if x >= base_items && x < self.num_items()? - 2 => {
                 let x = item_n - base_items;
                 let (op, idx) = self.op_with_item(x).map_err(|_| ViewError::NoData)?;
                 op.render_item(idx, title, message, page)
             }
-            x if x == self.num_items() as u8 - 2 => {
+            x if x == self.num_items()? - 2 => {
                 let title_content = pic_str!(b"Fee(AVAX)");
                 title[..title_content.len()].copy_from_slice(title_content);
 

--- a/app/src/parser/transactions/avm/operation_tx.rs
+++ b/app/src/parser/transactions/avm/operation_tx.rs
@@ -97,7 +97,7 @@ impl<'b> OperationTx<'b> {
             .get_obj_if(filter)
             .ok_or(ParserError::DisplayIdxOutOfRange)?;
 
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 
     fn render_outputs(

--- a/app/src/parser/transactions/base_export.rs
+++ b/app/src/parser/transactions/base_export.rs
@@ -234,7 +234,7 @@ where
         };
 
         let obj = self.outputs.get_obj_if(filter).ok_or(ViewError::NoData)?;
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 
     // default render_item implementation that

--- a/app/src/parser/transactions/base_import.rs
+++ b/app/src/parser/transactions/base_import.rs
@@ -156,7 +156,7 @@ where
             .map_err(|_| ViewError::Unknown)
     }
 
-    pub fn num_input_items(&'b self) -> usize {
+    pub fn num_input_items(&'b self) -> Result<u8, ViewError> {
         self.base_tx.base_outputs_num_items()
     }
 
@@ -175,7 +175,7 @@ where
         let obj = (*obj).secp_transfer().ok_or(ViewError::NoData)?;
 
         // get the number of items for the obj wrapped up by PvmOutput
-        let num_inner_items = obj.num_items() as _;
+        let num_inner_items = obj.num_items()?;
 
         // do a custom rendering of the first base_output_items
         match obj_item_n {

--- a/app/src/parser/transactions/base_tx_fields.rs
+++ b/app/src/parser/transactions/base_tx_fields.rs
@@ -174,7 +174,7 @@ where
             .get_obj_if(filter)
             .ok_or(ParserError::DisplayIdxOutOfRange)?;
 
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 }
 

--- a/app/src/parser/transactions/pvm/add_delegator.rs
+++ b/app/src/parser/transactions/pvm/add_delegator.rs
@@ -145,7 +145,7 @@ impl<'b> DisplayableItem for AddDelegatorTx<'b> {
                     let label = pic_str!(b"AddDelegator");
                     title[..label.len()].copy_from_slice(label);
                     let content = pic_str!(b"Transaction");
-                    return handle_ui_message(content, message, page);
+                    handle_ui_message(content, message, page)
                 },
                 until base_outputs_items => self.render_base_outputs(x, title, message, page),
                 until validator_items => self.validator.render_item(x, title, message, page),
@@ -377,7 +377,7 @@ impl<'b> AddDelegatorTx<'b> {
 
         let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];
         let num_addresses = self.rewards_owner.addresses.len() as u8;
-        let fee_items = 1 as u8;
+        let fee_items = 1;
 
         match_ranges! {
             match item_n alias x {
@@ -439,7 +439,7 @@ impl<'b> AddDelegatorTx<'b> {
             .stake
             .get_obj_if(filter)
             .ok_or(ParserError::DisplayIdxOutOfRange)?;
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 }
 

--- a/app/src/parser/transactions/pvm/add_delegator.rs
+++ b/app/src/parser/transactions/pvm/add_delegator.rs
@@ -20,6 +20,7 @@ use nom::number::complete::be_u32;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, Address, BaseTxFields, DisplayableItem, FromBytes, Header, ObjectList,
@@ -106,14 +107,23 @@ impl<'b> FromBytes<'b> for AddDelegatorTx<'b> {
 }
 
 impl<'b> DisplayableItem for AddDelegatorTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // tx_info, base_tx items, validator_items(4),
         // rewards_to, stake items and fee
-        1 + self.base_tx.base_outputs_num_items()
-            + self.validator.num_items()
-            + self.rewards_owner.addresses.len()
-            + self.num_stake_items()
-            + 1
+        //
+        let validator_items = self.validator.num_items()?;
+        let rewards_items = self.rewards_owner.addresses.len() as u8;
+        let base_outputs = self.base_tx.base_outputs_num_items()?;
+        let stake_items = self.num_stake_items()?;
+
+        checked_add!(
+            ViewError::Unknown,
+            2u8,
+            validator_items,
+            rewards_items,
+            base_outputs,
+            stake_items
+        )
     }
 
     fn render_item(
@@ -123,11 +133,11 @@ impl<'b> DisplayableItem for AddDelegatorTx<'b> {
         message: &mut [u8],
         page: u8,
     ) -> Result<u8, zemu_sys::ViewError> {
-        let validator_items = self.validator.num_items() as u8;
-        let base_outputs_items = self.base_tx.base_outputs_num_items() as u8;
-        let stake_outputs_items = self.num_stake_items() as u8;
+        let validator_items = self.validator.num_items()?;
+        let base_outputs_items = self.base_tx.base_outputs_num_items()?;
+        let stake_outputs_items = self.num_stake_items()?;
 
-        let total_items = self.num_items() as u8;
+        let total_items = self.num_items()?;
 
         match_ranges! {
             match item_n alias x {
@@ -184,17 +194,34 @@ impl<'b> AddDelegatorTx<'b> {
         Ok(fee)
     }
 
-    fn num_stake_items(&self) -> usize {
+    fn num_stake_items(&self) -> Result<u8, ViewError> {
         let mut items = 0;
         let mut idx = 0;
+
+        // store an error during execution, specifically
+        // if an overflows happens
+        let mut err: Option<ViewError> = None;
+
+        // iterate over outputs
         self.stake.iterate_with(|o| {
             let render = self.renderable_out & (1 << idx);
             if render > 0 {
-                items += o.num_items();
+                match o
+                    .num_items()
+                    .and_then(|a| a.checked_add(items).ok_or(ViewError::Unknown))
+                {
+                    Ok(i) => items = i,
+                    Err(_) => err = Some(ViewError::Unknown),
+                }
             }
+
             idx += 1;
         });
-        items
+
+        if err.is_some() {
+            return Err(ViewError::Unknown);
+        }
+        Ok(items)
     }
 
     fn render_base_outputs(
@@ -253,7 +280,7 @@ impl<'b> AddDelegatorTx<'b> {
         //      0.5 AVAX until 2021-05-31 21:28:00 UTC
 
         // get the number of items for the obj wrapped up by PvmOutput
-        let num_inner_items = obj.output.num_inner_items() as _;
+        let num_inner_items = obj.output.num_inner_items()?;
 
         // do a custom rendering of the first base_output_items
         match item_n {
@@ -394,7 +421,10 @@ impl<'b> AddDelegatorTx<'b> {
                 return false;
             }
 
-            let n = o.num_items();
+            let Ok(n) = o.num_items() else {
+                return false;
+            };
+
             for index in 0..n {
                 count += 1;
                 obj_item_n = index;

--- a/app/src/parser/transactions/pvm/add_subnet_validator.rs
+++ b/app/src/parser/transactions/pvm/add_subnet_validator.rs
@@ -13,7 +13,7 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 ********************************************************************************/
-use crate::sys::ViewError;
+use crate::{checked_add, sys::ViewError};
 use core::{mem::MaybeUninit, ptr::addr_of_mut};
 use nom::bytes::complete::tag;
 
@@ -73,10 +73,10 @@ impl<'b> FromBytes<'b> for AddSubnetValidatorTx<'b> {
 }
 
 impl<'b> DisplayableItem for AddSubnetValidatorTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // tx_info, validator_items(4),
         // subnet_id and fee
-        1 + self.validator.num_items() + 1 + 1
+        checked_add!(ViewError::Unknown, 3u8, self.validator.num_items()?)
     }
 
     fn render_item(
@@ -98,7 +98,7 @@ impl<'b> DisplayableItem for AddSubnetValidatorTx<'b> {
 
         let item_n = item_n - 1;
 
-        let validator_items = self.validator.num_items() as u8;
+        let validator_items = self.validator.num_items()?;
 
         match item_n {
             // render validator info

--- a/app/src/parser/transactions/pvm/add_validator.rs
+++ b/app/src/parser/transactions/pvm/add_validator.rs
@@ -145,7 +145,7 @@ impl<'b> DisplayableItem for AddValidatorTx<'b> {
                     let label = pic_str!(b"AddValidator");
                     title[..label.len()].copy_from_slice(label);
                     let content = pic_str!(b"Transaction");
-                    return handle_ui_message(content, message, page);
+                    handle_ui_message(content, message, page)
                 },
                 until base_outputs_items => self.render_base_outputs(x, title, message, page),
                 until validator_items => self.validator.render_item(x, title, message, page),
@@ -377,8 +377,8 @@ impl<'b> AddValidatorTx<'b> {
         let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];
         let num_addresses = self.rewards_owner.addresses.len() as u8;
 
-        let delegate_fee_items = 1 as u8;
-        let fee_items = 1 as u8;
+        let delegate_fee_items = 1;
+        let fee_items = 1;
 
         match_ranges! {
             match item_n alias x {
@@ -443,7 +443,7 @@ impl<'b> AddValidatorTx<'b> {
             .stake
             .get_obj_if(filter)
             .ok_or(ParserError::DisplayIdxOutOfRange)?;
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 }
 

--- a/app/src/parser/transactions/pvm/add_validator.rs
+++ b/app/src/parser/transactions/pvm/add_validator.rs
@@ -19,6 +19,7 @@ use nom::{bytes::complete::tag, number::complete::be_u32};
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         intstr_to_fpstr_inplace, nano_avax_to_fp_str, u64_to_str, Address, BaseTxFields,
@@ -114,15 +115,15 @@ impl<'b> FromBytes<'b> for AddValidatorTx<'b> {
 }
 
 impl<'b> DisplayableItem for AddValidatorTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // tx_info, base_tx items, validator_items(4),
         // fee, fee_delegation, rewards_to and stake items
-        1 + self.base_tx.base_outputs_num_items()
-            + self.validator.num_items()
-            + self.rewards_owner.num_addresses()
-            + self.num_stake_items()
-            + 1
-            + 1
+        let base = self.base_tx.base_outputs_num_items()?;
+        let rewards = self.rewards_owner.num_addresses() as u8;
+        let stake = self.num_stake_items()?;
+        let validator = self.validator.num_items()?;
+
+        checked_add!(ViewError::Unknown, 3u8, base, rewards, stake, validator)
     }
 
     fn render_item(
@@ -132,11 +133,11 @@ impl<'b> DisplayableItem for AddValidatorTx<'b> {
         message: &mut [u8],
         page: u8,
     ) -> Result<u8, zemu_sys::ViewError> {
-        let validator_items = self.validator.num_items() as u8;
-        let base_outputs_items = self.base_tx.base_outputs_num_items() as u8;
-        let stake_outputs_items = self.num_stake_items() as u8;
+        let validator_items = self.validator.num_items()?;
+        let base_outputs_items = self.base_tx.base_outputs_num_items()?;
+        let stake_outputs_items = self.num_stake_items()?;
 
-        let total_items = self.num_items() as u8;
+        let total_items = self.num_items()?;
 
         match_ranges! {
             match item_n alias x {
@@ -194,17 +195,32 @@ impl<'b> AddValidatorTx<'b> {
         Ok(fee)
     }
 
-    fn num_stake_items(&self) -> usize {
+    fn num_stake_items(&self) -> Result<u8, ViewError> {
         let mut items = 0;
         let mut idx = 0;
+
+        // store an error during execution, specifically
+        // if an overflows happens
+        let mut err: Option<ViewError> = None;
+
         self.stake.iterate_with(|o| {
             let render = self.renderable_out & (1 << idx);
             if render > 0 {
-                items += o.num_items();
+                match o
+                    .num_items()
+                    .and_then(|a| a.checked_add(items).ok_or(ViewError::Unknown))
+                {
+                    Ok(i) => items = i,
+                    Err(_) => err = Some(ViewError::Unknown),
+                }
             }
             idx += 1;
         });
-        items
+
+        if err.is_some() {
+            return Err(ViewError::Unknown);
+        }
+        Ok(items)
     }
 
     fn render_base_outputs(
@@ -263,7 +279,7 @@ impl<'b> AddValidatorTx<'b> {
         //      0.5 AVAX until 2021-05-31 21:28:00 UTC
 
         // get the number of items for the obj wrapped up by PvmOutput
-        let num_inner_items = obj.output.num_inner_items() as _;
+        let num_inner_items = obj.output.num_inner_items()?;
 
         // do a custom rendering of the first base_output_items
         match item_n {
@@ -409,7 +425,10 @@ impl<'b> AddValidatorTx<'b> {
                 return false;
             }
 
-            let n = o.num_items();
+            let Ok(n) = o.num_items() else {
+                return false;
+            };
+
             for index in 0..n {
                 count += 1;
                 obj_item_n = index;
@@ -489,7 +508,7 @@ mod tests {
         let mut title = [0; 100];
         let mut value = [0; 100];
 
-        for i in 0..tx.num_items() {
+        for i in 0..tx.num_items().expect("Overflow?") {
             tx.render_item(i as _, title.as_mut(), value.as_mut(), 0)
                 .unwrap();
             let t = std::string::String::from_utf8_lossy(&title);

--- a/app/src/parser/transactions/pvm/banff/add_permissionless_delegator.rs
+++ b/app/src/parser/transactions/pvm/banff/add_permissionless_delegator.rs
@@ -153,7 +153,7 @@ impl<'b> DisplayableItem for AddPermissionlessDelegatorTx<'b> {
                     let label = pic_str!(b"AddPermlessDelega");
                     title[..label.len()].copy_from_slice(label);
                     let content = pic_str!(b"Transaction");
-                    return handle_ui_message(content, message, page);
+                    handle_ui_message(content, message, page)
                 },
                 until base_outputs_items => self.render_base_outputs(x, title, message, page),
                 until validator_items => self.validator.render_item(x, title, message, page),
@@ -384,7 +384,7 @@ impl<'b> AddPermissionlessDelegatorTx<'b> {
 
         let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];
         let num_addresses = self.rewards_owner.addresses.len() as u8;
-        let fee_items = 1 as u8;
+        let fee_items = 1;
 
         match_ranges! {
             match item_n alias x {
@@ -445,7 +445,7 @@ impl<'b> AddPermissionlessDelegatorTx<'b> {
             .stake
             .get_obj_if(filter)
             .ok_or(ParserError::DisplayIdxOutOfRange)?;
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 }
 

--- a/app/src/parser/transactions/pvm/banff/add_permissionless_delegator.rs
+++ b/app/src/parser/transactions/pvm/banff/add_permissionless_delegator.rs
@@ -20,6 +20,7 @@ use nom::number::complete::be_u32;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, Address, BaseTxFields, DisplayableItem, FromBytes, Header, ObjectList,
@@ -112,16 +113,23 @@ impl<'b> FromBytes<'b> for AddPermissionlessDelegatorTx<'b> {
 }
 
 impl<'b> DisplayableItem for AddPermissionlessDelegatorTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // tx_info, base_tx items, validator_items(4),
         // subnet id, rewards_to,
         // stake items and fee
-        1 + self.base_tx.base_outputs_num_items()
-            + self.validator.num_items()
-            + 1
-            + self.rewards_owner.addresses.len()
-            + self.num_stake_items()
-            + 1
+        let base_outputs = self.base_tx.base_outputs_num_items()?;
+        let validator_items = self.validator.num_items()?;
+        let owners = self.rewards_owner.addresses.len() as u8;
+        let stake = self.num_stake_items()?;
+
+        checked_add!(
+            ViewError::Unknown,
+            3u8,
+            base_outputs,
+            validator_items,
+            owners,
+            stake
+        )
     }
 
     fn render_item(
@@ -131,12 +139,12 @@ impl<'b> DisplayableItem for AddPermissionlessDelegatorTx<'b> {
         message: &mut [u8],
         page: u8,
     ) -> Result<u8, zemu_sys::ViewError> {
-        let validator_items = self.validator.num_items() as u8;
-        let base_outputs_items = self.base_tx.base_outputs_num_items() as u8;
-        let stake_outputs_items = self.num_stake_items() as u8;
-        let subnet_id_items = self.subnet_id.num_items() as u8;
+        let validator_items = self.validator.num_items()?;
+        let base_outputs_items = self.base_tx.base_outputs_num_items()?;
+        let stake_outputs_items = self.num_stake_items()?;
+        let subnet_id_items = self.subnet_id.num_items()?;
 
-        let total_items = self.num_items() as u8;
+        let total_items = self.num_items()?;
 
         match_ranges! {
             match item_n alias x {
@@ -195,17 +203,32 @@ impl<'b> AddPermissionlessDelegatorTx<'b> {
         Ok(fee)
     }
 
-    fn num_stake_items(&self) -> usize {
+    fn num_stake_items(&self) -> Result<u8, ViewError> {
         let mut items = 0;
         let mut idx = 0;
+
+        // store an error during execution, specifically
+        // if an overflows happens
+        let mut err: Option<ViewError> = None;
+
         self.stake.iterate_with(|o| {
             let render = self.renderable_out & (1 << idx);
             if render > 0 {
-                items += o.num_items();
+                match o
+                    .num_items()
+                    .and_then(|a| a.checked_add(items).ok_or(ViewError::Unknown))
+                {
+                    Ok(i) => items = i,
+                    Err(_) => err = Some(ViewError::Unknown),
+                }
             }
             idx += 1;
         });
-        items
+
+        if err.is_some() {
+            return Err(ViewError::Unknown);
+        }
+        Ok(items)
     }
 
     fn render_base_outputs(
@@ -264,7 +287,7 @@ impl<'b> AddPermissionlessDelegatorTx<'b> {
         //      0.5 AVAX until 2021-05-31 21:28:00 UTC
 
         // get the number of items for the obj wrapped up by PvmOutput
-        let num_inner_items = obj.output.num_inner_items() as _;
+        let num_inner_items = obj.output.num_inner_items()?;
 
         // do a custom rendering of the first base_output_items
         match item_n {
@@ -405,7 +428,9 @@ impl<'b> AddPermissionlessDelegatorTx<'b> {
                 return false;
             }
 
-            let n = o.num_items();
+            let Ok(n) = o.num_items() else {
+                return false;
+            };
             for index in 0..n {
                 count += 1;
                 obj_item_n = index;
@@ -451,9 +476,9 @@ mod tests {
             println!("-------------------- Add Permissionless Delegator TX #{i} ------------------------");
             let (_, tx) = AddPermissionlessDelegatorTx::from_bytes(data).unwrap();
 
-            let items = tx.num_items();
+            let items = tx.num_items().expect("Overflow!");
 
-            let mut pages = Vec::<Page<18, 1024>>::with_capacity(items);
+            let mut pages = Vec::<Page<18, 1024>>::with_capacity(items as usize);
             for i in 0..items {
                 let mut page = Page::default();
 

--- a/app/src/parser/transactions/pvm/banff/add_permissionless_validator.rs
+++ b/app/src/parser/transactions/pvm/banff/add_permissionless_validator.rs
@@ -176,7 +176,7 @@ impl<'b> DisplayableItem for AddPermissionlessValidatorTx<'b> {
                     let label = pic_str!(b"AddPermlessValida");
                     title[..label.len()].copy_from_slice(label);
                     let content = pic_str!(b"Transaction");
-                    return handle_ui_message(content, message, page);
+                     handle_ui_message(content, message, page)
                 },
                 until base_outputs_items => self.render_base_outputs(x, title, message, page),
                 until validator_items => self.validator.render_item(x, title, message, page),
@@ -419,8 +419,8 @@ impl<'b> AddPermissionlessValidatorTx<'b> {
         let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];
         let num_addresses = (self.validator_rewards_owner.num_addresses()
             + self.delegator_rewards_owner.num_addresses()) as u8;
-        let delegate_fee_items = 1 as u8;
-        let fee_items = 1 as u8;
+        let delegate_fee_items = 1;
+        let fee_items = 1;
 
         match_ranges! {
             match item_n alias x {
@@ -485,7 +485,7 @@ impl<'b> AddPermissionlessValidatorTx<'b> {
             .stake
             .get_obj_if(filter)
             .ok_or(ParserError::DisplayIdxOutOfRange)?;
-        Ok((obj, obj_item_n as u8))
+        Ok((obj, obj_item_n))
     }
 }
 

--- a/app/src/parser/transactions/pvm/banff/transform_subnet.rs
+++ b/app/src/parser/transactions/pvm/banff/transform_subnet.rs
@@ -24,6 +24,7 @@ use nom::{
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, AssetId, BaseTxFields, DisplayableItem, FromBytes, Header,
@@ -250,7 +251,7 @@ impl<'b> TransformSubnetTx<'b> {
 }
 
 impl<'b> DisplayableItem for TransformSubnetTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         let num_expert_items = if is_app_mode_expert() {
             // init/max supply + min/max consumption rate
             // + min/max stake duration
@@ -264,7 +265,13 @@ impl<'b> DisplayableItem for TransformSubnetTx<'b> {
 
         //tx info, subnet id, asset id, fee
         // + expert items
-        1 + self.subnet_id.num_items() + self.asset_id.num_items() + 1 + num_expert_items
+        checked_add!(
+            ViewError::Unknown,
+            2u8,
+            self.subnet_id.num_items()?,
+            self.asset_id.num_items()?,
+            num_expert_items
+        )
     }
 
     fn render_item(
@@ -373,9 +380,9 @@ mod tests {
             println!("-------------------- Transform Subnet TX #{i} ------------------------");
             let (_, tx) = TransformSubnetTx::from_bytes(data).unwrap();
 
-            let items = tx.num_items();
+            let items = tx.num_items().expect("Overflow?");
 
-            let mut pages = Vec::<Page<18, 1024>>::with_capacity(items);
+            let mut pages = Vec::<Page<18, 1024>>::with_capacity(items as usize);
             for i in 0..items {
                 let mut page = Page::default();
 

--- a/app/src/parser/transactions/pvm/create_chain_tx.rs
+++ b/app/src/parser/transactions/pvm/create_chain_tx.rs
@@ -122,11 +122,11 @@ impl<'b> FromBytes<'b> for CreateChainTx<'b> {
 }
 
 impl<'b> DisplayableItem for CreateChainTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // we need to show:
         // tx description, SubnetID, ChainName, VMID, GenesisDataHash
         // and fee
-        1 + 4 + 1
+        Ok(1 + 4 + 1)
     }
 
     fn render_item(

--- a/app/src/parser/transactions/pvm/create_subnet_tx.rs
+++ b/app/src/parser/transactions/pvm/create_subnet_tx.rs
@@ -18,6 +18,7 @@ use nom::bytes::complete::tag;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, BaseTxFields, DisplayableItem, FromBytes, Header, ParserError,
@@ -75,8 +76,8 @@ impl<'b> FromBytes<'b> for CreateSubnetTx<'b> {
 }
 
 impl<'b> DisplayableItem for CreateSubnetTx<'b> {
-    fn num_items(&self) -> usize {
-        1 + self.owners.num_items() + 1 //fee
+    fn num_items(&self) -> Result<u8, ViewError> {
+        checked_add!(ViewError::Unknown, 2u8, self.owners.num_items()?)
     }
 
     fn render_item(
@@ -89,7 +90,7 @@ impl<'b> DisplayableItem for CreateSubnetTx<'b> {
         use bolos::{pic_str, PIC};
         use lexical_core::Number;
 
-        let owners_items = self.owners.num_items() as u8;
+        let owners_items = self.owners.num_items()?;
 
         if item_n == 0 {
             let label = pic_str!(b"CreateSubnet");

--- a/app/src/parser/transactions/pvm/export_tx.rs
+++ b/app/src/parser/transactions/pvm/export_tx.rs
@@ -19,6 +19,7 @@ use nom::bytes::complete::tag;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, BaseExport, DisplayableItem, FromBytes, ParserError, PvmOutput,
@@ -69,8 +70,10 @@ impl<'b> FromBytes<'b> for PvmExportTx<'b> {
 }
 
 impl<'b> DisplayableItem for PvmExportTx<'b> {
-    fn num_items(&self) -> usize {
-        1 + self.0.num_outputs_items() + 1
+    fn num_items(&self) -> Result<u8, ViewError> {
+        let outputs = self.0.num_outputs_items()?;
+
+        checked_add!(ViewError::Unknown, 2u8, outputs)
     }
 
     fn render_item(
@@ -88,7 +91,7 @@ impl<'b> DisplayableItem for PvmExportTx<'b> {
             return self.0.render_export_description(title, message, page);
         }
 
-        let outputs_num_items = self.0.num_outputs_items();
+        let outputs_num_items = self.0.num_outputs_items()?;
         let new_item_n = item_n - 1;
 
         match new_item_n {

--- a/app/src/parser/transactions/pvm/export_tx.rs
+++ b/app/src/parser/transactions/pvm/export_tx.rs
@@ -95,10 +95,8 @@ impl<'b> DisplayableItem for PvmExportTx<'b> {
         let new_item_n = item_n - 1;
 
         match new_item_n {
-            x @ 0.. if x < outputs_num_items as u8 => {
-                self.0.render_outputs(x, title, message, page)
-            }
-            x if x == outputs_num_items as u8 => {
+            x @ 0.. if x < outputs_num_items => self.0.render_outputs(x, title, message, page),
+            x if x == outputs_num_items => {
                 let title_content = pic_str!(b"Fee");
                 title[..title_content.len()].copy_from_slice(title_content);
                 let mut buffer = [0; u64::FORMATTED_SIZE_DECIMAL + 2];

--- a/app/src/parser/transactions/pvm/import_tx.rs
+++ b/app/src/parser/transactions/pvm/import_tx.rs
@@ -19,6 +19,7 @@ use nom::bytes::complete::tag;
 use zemu_sys::ViewError;
 
 use crate::{
+    checked_add,
     handlers::handle_ui_message,
     parser::{
         nano_avax_to_fp_str, BaseImport, DisplayableItem, FromBytes, ParserError, PvmOutput,
@@ -64,13 +65,13 @@ impl<'b> PvmImportTx<'b> {
 }
 
 impl<'b> DisplayableItem for PvmImportTx<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // only support SECP256k1 outputs
         // and to keep compatibility with the legacy app,
         // we show only 4 items for each output
         // tx info, amount, address and fee which is the sum of all inputs minus all outputs
         // and the chain description
-        1 + self.0.num_input_items() + 1 + 1
+        checked_add!(ViewError::Unknown, 3u8, self.0.num_input_items()?)
     }
 
     fn render_item(
@@ -90,7 +91,7 @@ impl<'b> DisplayableItem for PvmImportTx<'b> {
             return handle_ui_message(&value_content[..], message, page);
         }
 
-        let inputs_num_items = self.0.num_input_items() as u8;
+        let inputs_num_items = self.0.num_input_items()?;
         let new_item_n = item_n - 1;
 
         match new_item_n {

--- a/app/src/parser/utils.rs
+++ b/app/src/parser/utils.rs
@@ -226,6 +226,22 @@ pub fn intstr_to_fpstr_inplace(
     Ok(&mut s[..len])
 }
 
+#[macro_export]
+macro_rules! checked_add {
+    ($err_type:ident, $first:expr $(, $rest:expr)*) => {{
+        // Start with the first value
+        let mut sum = $first;
+
+        // Try to add each of the rest, checking for overflow
+        $(
+            sum = sum.checked_add($rest).ok_or($err_type)?;
+        )*
+
+        // If we reach here, the sum is valid
+        Ok(sum)
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::{intstr_to_fpstr_inplace, u64_to_str};

--- a/app/src/parser/utils.rs
+++ b/app/src/parser/utils.rs
@@ -228,7 +228,7 @@ pub fn intstr_to_fpstr_inplace(
 
 #[macro_export]
 macro_rules! checked_add {
-    ($err_type:ident, $first:expr $(, $rest:expr)*) => {{
+    ($err_type:path, $first:expr $(, $rest:expr)*) => {{
         // Start with the first value
         let mut sum = $first;
 

--- a/app/src/parser/validator.rs
+++ b/app/src/parser/validator.rs
@@ -64,9 +64,10 @@ impl<'b> FromBytes<'b> for Validator<'b> {
 }
 
 impl<'b> DisplayableItem for Validator<'b> {
-    fn num_items(&self) -> usize {
+    fn num_items(&self) -> Result<u8, ViewError> {
         // node_id(1), start_time, endtime and total_stake
-        self.node_id.num_items() + 3
+        let items = self.node_id.num_items()?;
+        items.checked_add(3).ok_or(ViewError::Unknown)
     }
 
     fn render_item(


### PR DESCRIPTION
Refactor `DisplayableItem::num_items` method to return a `Result<u8, ViewError>`
in this way, many casts to u8 were removed and we propagated possible overflows.