### PR TITLE
Fix/avax path

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -264,8 +264,6 @@ ifeq (,$(filter $(TARGET_NAME),TARGET_NANOS TARGET_STAX))
 	# mainnet or testnet. lets pick 
 	# the ones for mainnet for now
 	DEFINES   += BIP32_PUBKEY_VERSION=0x0488B21E
-	DEFINES   += BIP44_COIN_TYPE=0
-	DEFINES   += BIP44_COIN_TYPE_2=0
 	# The coin type bellow is not part of the btc app,
 	# but this is necesary here as avax wants support for 
 	# coin_type = 60'

--- a/app/c/handler.c
+++ b/app/c/handler.c
@@ -57,11 +57,6 @@ const command_descriptor_t COMMAND_DESCRIPTORS[] = {
     },
     {
         .cla = CLA_APP,
-        .ins = REGISTER_WALLET,
-        .handler = (command_handler_t)handler_register_wallet
-    },
-    {
-        .cla = CLA_APP,
         .ins = SIGN_PSBT,
         .handler = (command_handler_t)handler_sign_psbt
     },


### PR DESCRIPTION
This:
- Remove no longer required compilation flags, which were used to set valid coin-types for the btc app, however, btc-integration only supports one coin-type 60'
- update btc module which enforces that our integration only works with 44'/60'/x'/n/n paths for security reasons.