### PR TITLE
Disable BTC integration

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -26,9 +26,9 @@ all: bin/app.elf
 	@echo "#!/usr/bin/env bash" > $(OUTPUT_INSTALLER)
 	@echo "APPNAME=\"${APPNAME}\"" >> $(OUTPUT_INSTALLER)
 	@echo "APPVERSION=\"${APPVERSION}\"" >> $(OUTPUT_INSTALLER)
-	# Commented due to a crash when trying to sign BTC transactions, it needs to be allowed to 
-	# use generic paths, instead of being limited to the paths passed bellow.
-	# @echo "APPPATH=\""${APPPATH}"\"" >> $(OUTPUT_INSTALLER)
+ifneq ($(FEATURE_BTC), 1)
+	@echo "APPPATH=\""${APPPATH}"\"" >> $(OUTPUT_INSTALLER)
+endif
 	@echo "LOAD_PARAMS=($$(echo "${APP_LOAD_PARAMS}" | sed -e "s|"${APPNAME}"|\""${APPNAME}"\"|"))" >> $(OUTPUT_INSTALLER)
 	@echo "DELETE_PARAMS=($$(echo "${COMMON_DELETE_PARAMS}" | sed -e "s|"${APPNAME}"|\""${APPNAME}"\"|"))" >> $(OUTPUT_INSTALLER)
 	@echo "APPHEX=\"" >> $(OUTPUT_INSTALLER)
@@ -41,8 +41,7 @@ all: bin/app.elf
 	@rm $(ARTIFACT_OUTPUT_PATH)/output/app.elf
 
 include $(BOLOS_SDK)/Makefile.defines
-
-DEFINES += APP_SECRET_MODE_ENABLED
+include $(CURDIR)/Makefile.conf
 
 $(info ************ TARGET_NAME  = [$(TARGET_NAME)])
 
@@ -55,8 +54,6 @@ endif
 ifndef COIN
 COIN=AVAX
 endif
-
-include $(CURDIR)/Makefile.version
 
 $(info COIN  = [$(COIN)])
 ifeq ($(COIN),AVAX)
@@ -90,10 +87,11 @@ ICONNAME:=$(CURDIR)/../nanox_icon.gif
 OUTPUT_ELF ?= $(ARTIFACT_OUTPUT_PATH)/output/app_x.elf
 OUTPUT_INSTALLER:= $(ARTIFACT_OUTPUT_PATH)/pkg/installer_x.sh
 RUST_TARGET:=thumbv6m-none-eabi
-# for BTC we need to remove the 0x200 flag and 
-# replace it with 0xa50
-# otherwise, app crashes
+ifeq ($(FEATURE_BTC), 1))
 APP_LOAD_PARAMS += --appFlags 0xa50
+else
+APP_LOAD_PARAMS += --appFlags 0x200
+endif
 APP_FULL:=1
 endif
 
@@ -103,10 +101,11 @@ OUTPUT_ELF ?= $(ARTIFACT_OUTPUT_PATH)/output/app_sp.elf
 OUTPUT_INSTALLER:= $(ARTIFACT_OUTPUT_PATH)/pkg/installer_sp.sh
 #RUST_TARGET:=thumbv8m.main-none-eabi
 RUST_TARGET:=thumbv6m-none-eabi
-# for BTC we need to remove the 0x000 flag and 
-# replace it with 0xa50
-# otherwise, app crashes
+ifeq ($(FEATURE_BTC), 1))
 APP_LOAD_PARAMS += --appFlags 0xa50
+else
+APP_LOAD_PARAMS += --appFlags 0x200
+endif
 APP_FULL:=1
 endif
 
@@ -115,12 +114,7 @@ ICONNAME:=$(CURDIR)/../stax_icon.gif
 OUTPUT_ELF ?= $(ARTIFACT_OUTPUT_PATH)/output/app_fs.elf
 OUTPUT_INSTALLER:= $(ARTIFACT_OUTPUT_PATH)/pkg/installer_fs.sh
 RUST_TARGET:=thumbv6m-none-eabi
-# for BTC we need to remove the 0x200 flag and
-# replace it with 0xa50
-# otherwise the app will crash
-# - BTC for stax is disabled temporarily, but it will be enabled soon
-# - so let's keep these flags
-APP_LOAD_PARAMS += --appFlags 0xa50
+APP_LOAD_PARAMS += --appFlags 0x200
 APP_FULL:=1
 endif
 
@@ -255,41 +249,40 @@ endif
 
 APP_CUSTOM_LINK_DEPENDENCIES := rust
 
-# Do not compile btc app if target is nanos or stax
-ifeq (,$(filter $(TARGET_NAME),TARGET_NANOS TARGET_STAX))
+ifeq ($(FEATURE_BTC), 1)
+	# Do not compile btc app if target is nanos or stax
+	ifeq (,$(filter $(TARGET_NAME),TARGET_NANOS TARGET_STAX))
+		DEFINES += HAVE_BTC_INTEGRATION
 
-	# Bitcoin mainnet, no legacy support
-	# TODO: the new-bitcoin-app's assigns different 
-	# values for the variables bellow depending on
-	# mainnet or testnet. lets pick 
-	# the ones for mainnet for now
-	DEFINES   += BIP32_PUBKEY_VERSION=0x0488B21E
-	# The coin type bellow is not part of the btc app,
-	# but this is necesary here as avax wants support for 
-	# coin_type = 60'
-	DEFINES   += BIP44_COIN_TYPE_3=60
-	DEFINES   += COIN_P2PKH_VERSION=0
-	DEFINES   += COIN_P2SH_VERSION=5
-	DEFINES   += COIN_NATIVE_SEGWIT_PREFIX=\"bc\"
-	DEFINES   += COIN_COINID_SHORT=\"BTC\"
+		# Bitcoin mainnet, no legacy support
+		# TODO: the new-bitcoin-app's assigns different
+		# values for the variables bellow depending on
+		# mainnet or testnet. lets pick
+		# the ones for mainnet for now
+		DEFINES   += BIP32_PUBKEY_VERSION=0x0488B21E
 
-	# Needed to be able to include the definition of G_cx
-	INCLUDES_PATH += $(BOLOS_SDK)/lib_cxng/src
-	INCLUDES_PATH += $(MY_DIR)/../deps/btc/src
-	INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/boilerplate/
-	INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/common/
-	INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/handler/
-	INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/swap/
-	INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/ui/
+		# The coin type bellow is not part of the btc app,
+		# but this is necesary here as avax wants support for
+		# coin_type = 60'
+		DEFINES   += BIP44_COIN_TYPE_3=60
+		DEFINES   += COIN_P2PKH_VERSION=0
+		DEFINES   += COIN_P2SH_VERSION=5
+		DEFINES   += COIN_NATIVE_SEGWIT_PREFIX=\"bc\"
+		DEFINES   += COIN_COINID_SHORT=\"BTC\"
 
-	APP_SOURCE_PATH += $(MY_DIR)/../deps/btc/src
-	DEFINES   += HAVE_BOLOS_APP_STACK_CANARY
+		# Needed to be able to include the definition of G_cx
+		INCLUDES_PATH += $(BOLOS_SDK)/lib_cxng/src
 
-	ifeq ($(TARGET_NAME),$(filter $(TARGET_NAME),TARGET_NANOX TARGET_STAX))
-		DEFINES       += HAVE_BLE BLE_COMMAND_TIMEOUT_MS=2000
-		DEFINES       += HAVE_BLE_APDU
-	endif
-endif #NO TARGET_NANOS OR TARGET_STAX
+		INCLUDES_PATH += $(MY_DIR)/../deps/btc/src
+		INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/boilerplate/
+		INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/common/
+		INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/handler/
+		INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/swap/
+		INCLUDES_PATH += $(MY_DIR)/../deps/btc/src/ui/
+
+		APP_SOURCE_PATH += $(MY_DIR)/../deps/btc/src
+	endif #NO TARGET_NANOS OR TARGET_STAX
+endif #NO FEATURE_BTC
 
 .PHONY: rust
 rust:

--- a/app/Makefile.conf
+++ b/app/Makefile.conf
@@ -1,0 +1,10 @@
+# Configuration flags and values for app features
+
+#Specifies the version of the app
+include Makefile.version
+
+# Enable debug output in speculos and other development features
+APP_TESTING ?= 0
+
+# Enable BTC integration in the app
+FEATURE_BTC ?= 0

--- a/app/c/handler.c
+++ b/app/c/handler.c
@@ -15,9 +15,7 @@
  *  limitations under the License.
  ********************************************************************************/
 
-#include "bolos_target.h"
-
-#if defined(TARGET_NANOX) || defined(TARGET_NANOS2)
+#if defined(HAVE_BTC_INTEGRATION)
 #include "globals.h"
 // #include "io.h"
 #include "boilerplate/apdu_parser.h"

--- a/app/c/handler.h
+++ b/app/c/handler.h
@@ -1,36 +1,36 @@
 /*******************************************************************************
-*   (c) 2016 Ledger
-*   (c) 2018-2023 Zondax AG
-*
-*  Licensed under the Apache License, Version 2.0 (the "License");
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an "AS IS" BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-********************************************************************************/
+ *   (c) 2016 Ledger
+ *   (c) 2018-2023 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
 #include "rslib.h"
 
-#include "boilerplate/io.h"
-#include "boilerplate/sw.h"
+#if defined(HAVE_BTC_INTEGRATION)
 #include "boilerplate/apdu_parser.h"
 #include "boilerplate/constants.h"
 #include "boilerplate/dispatcher.h"
+#include "boilerplate/io.h"
+#include "boilerplate/sw.h"
 
-#include <os_io_seproxyhal.h>
 #include <os.h>
+#include <os_io_seproxyhal.h>
 
 #define APDU_INDEX_CLA 0
 #define OFFSET_CLA 0
 
 void btc_state_reset();
-
-unsigned char handle_event(unsigned char channel);
-void handle_btc_apdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx,  const uint8_t *buffer, uint16_t bufferLen);
+void handle_btc_apdu(volatile uint32_t *flags, volatile uint32_t *tx,
+                     uint32_t rx, const uint8_t *buffer, uint16_t bufferLen);
 void initialize_app_globals();
-
+#endif

--- a/app/c/main.c
+++ b/app/c/main.c
@@ -18,7 +18,7 @@
 #include <os.h>
 #include <os_io_seproxyhal.h>
 
-#if defined(TARGET_NANOX) || defined(TARGET_NANOS2)
+#if defined(HAVE_BTC_INTEGRATION)
 #include "globals.h"
 #include "handler.h"
 #else
@@ -27,7 +27,7 @@
 
 uint8_t G_io_seproxyhal_spi_buffer[IO_SEPROXYHAL_BUFFER_SIZE_B];
 
-#if defined(TARGET_NANOS) || defined(TARGET_STAX)
+#if !defined(HAVE_BTC_INTEGRATION)
 unsigned char io_event(unsigned char channel) {
   switch (G_io_seproxyhal_spi_buffer[0]) {
   case SEPROXYHAL_TAG_FINGER_EVENT: //
@@ -121,13 +121,13 @@ __attribute__((section(".boot"))) int main(void) {
   volatile uint32_t rx = 0, tx = 0, flags = 0;
   volatile uint16_t sw = 0;
   zemu_log_stack("main");
-#if !defined(TARGET_NANOS) && !defined(TARGET_STAX)
+#if defined(HAVE_BTC_INTEGRATION)
   initialize_app_globals();
   btc_state_reset();
 #endif /* ifndef TARGET_NANOS */
 
   for (;;) {
-#if !defined(TARGET_NANOS) && !defined(TARGET_STAX)
+#if defined(HAVE_BTC_INTEGRATION)
     // Reset length of APDU response
     G_output_len = 0;
 #endif
@@ -148,8 +148,7 @@ __attribute__((section(".boot"))) int main(void) {
         flags = 0;
         check_canary();
 
-// Btc apdu commands are not supported by nanos
-#if defined(TARGET_NANOS) || defined(TARGET_STAX)
+#if !defined(HAVE_BTC_INTEGRATION)
         rs_handle_apdu(&flags, &tx, rx, G_io_apdu_buffer, IO_APDU_BUFFER_SIZE);
 #else
         if (G_io_apdu_buffer[OFFSET_CLA] == CLA_APP ||

--- a/deps/zxlib/view.c
+++ b/deps/zxlib/view.c
@@ -38,8 +38,7 @@
 ///////////////////////////////////
 // General
 
-// Other targets will use btc declarations
-#if defined(TARGET_NANOS)
+#if !defined(HAVE_BTC_INTEGRATION) && !defined(TARGET_STAX)
 void io_seproxyhal_display(const bagl_element_t *element) {
   io_seproxyhal_display_default((bagl_element_t *)element);
 }

--- a/zemu/package.json
+++ b/zemu/package.json
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "description": "",
   "types": "./dist/index.d.ts",
-  "keywords": [
-    "Zondax",
-    "Ledger"
-  ],
+  "keywords": ["Zondax", "Ledger"],
   "scripts": {
-    "test": "jest --testPathIgnorePatterns='dev.*|testvectors.*'",
+    "test": "jest --testPathIgnorePatterns='dev.*|testvectors.*|btc.*'",
     "test_dev": "jest",
     "try": "node try.mjs",
     "debug": "node debug/debug.mjs debug"

--- a/zemu/tests/common.ts
+++ b/zemu/tests/common.ts
@@ -16,15 +16,15 @@ export const models: IDeviceModel[] = [
   { name: 'stax', prefix: 'ST', path: APP_PATH_ST },
 ]
 
-export const btc_models: IDeviceModel[] = models.filter((m) => m.name != 'nanos' && m.name != 'stax')
+export const btc_models: IDeviceModel[] = models.filter(m => m.name != 'nanos' && m.name != 'stax')
 
 export const defaultOptions = (m: IDeviceModel, is_address = false) => {
-  let approveAction = ButtonKind.ApproveHoldButton;
-  let approveKeyword = "";
+  let approveAction = ButtonKind.ApproveHoldButton
+  let approveKeyword = ''
 
   if (m.name == 'stax' && is_address) {
-    approveKeyword = 'Show as QR';
-    approveAction = ButtonKind.ApproveTapButton;
+    approveKeyword = 'Show as QR'
+    approveAction = ButtonKind.ApproveTapButton
   }
 
   return {


### PR DESCRIPTION
This PR disabled the BTC integration, allowing it to be enabled during compilation via make configuration.

To enable the integration, edit `app/Makefile.conf` to set `FEATURE_BTC` to 1 (can be set via environment and command line via make facilities)