### PR TITLE
Address PR review: validate node_id length prefix, fix test typing

### DIFF
--- a/app/rust/src/parser/transactions/pvm/banff/add_auto_renewed_validator.rs
+++ b/app/rust/src/parser/transactions/pvm/banff/add_auto_renewed_validator.rs
@@ -16,7 +16,7 @@
 use bolos::{pic_str, PIC};
 use core::{mem::MaybeUninit, ptr::addr_of_mut};
 use nom::{
-    bytes::complete::{tag, take},
+    bytes::complete::tag,
     number::complete::{be_u32, be_u64},
 };
 use zemu_sys::ViewError;
@@ -28,7 +28,7 @@ use crate::{
         intstr_to_fpstr_inplace, nano_avax_to_fp_str, proof_of_possession::BLSSigner, u64_to_str,
         BaseTxFields, DisplayableItem, FromBytes, Header, NodeId, ObjectList, OutputIdx,
         ParserError, PvmOutput, SECPOutputOwners, TransferableOutput, DELEGATION_FEE_DIGITS,
-        MAX_ADDRESS_ENCODED_LEN, PVM_ADD_AUTO_RENEWED_VALIDATOR, U64_FORMATTED_SIZE,
+        MAX_ADDRESS_ENCODED_LEN, NODE_ID_LEN, PVM_ADD_AUTO_RENEWED_VALIDATOR, U64_FORMATTED_SIZE,
     },
 };
 
@@ -78,8 +78,13 @@ impl<'b> FromBytes<'b> for AddAutoRenewedValidatorTx<'b> {
         crate::sys::zemu_log_stack("AutoRenewed::base_tx ok\x00");
 
         // node_id: avalanchego types it as a JSONByteSlice ([]byte), so the codec
-        // emits a 4-byte length prefix before the 20-byte id. Skip it, like L1Validator.
-        let (rem, _) = take(4usize)(rem)?;
+        // emits a 4-byte big-endian length prefix before the 20-byte id. Validate the
+        // prefix equals NODE_ID_LEN; a mismatched length would otherwise misalign the
+        // rest of the parse and let us display a node_id that differs from what is signed.
+        let (rem, node_id_len) = be_u32(rem)?;
+        if node_id_len as usize != NODE_ID_LEN {
+            return Err(ParserError::InvalidLength.into());
+        }
         let node_id = unsafe { &mut *addr_of_mut!((*out).node_id).cast() };
         let rem = NodeId::from_bytes_into(rem, node_id)?;
         crate::sys::zemu_log_stack("AutoRenewed::node_id ok\x00");

--- a/tests_zemu/tests/eth.test.ts
+++ b/tests_zemu/tests/eth.test.ts
@@ -312,7 +312,8 @@ describe.each(models)('EthereumTx [%s]; sign', function (m) {
     const sim = new Zemu(m.path)
     // signEVMTransaction is deferred (IO_ASYNCH_REPLY) once the warning shows and
     // only settles when the screen is dismissed — here, when the container closes.
-    let signReq: Promise<unknown> | undefined
+    // Definite assignment: it is always set in the try below before any use.
+    let signReq!: Promise<unknown>
     try {
       await sim.start(defaultOptions(m)) // blind signing OFF
       const app = new AvalancheApp(sim.getTransport())


### PR DESCRIPTION
Addresses the Copilot review comments raised on the upstream PR.

## Changes

**`AddAutoRenewedValidatorTx` — validate the node_id length prefix**
avalanchego types `node_id` as a `JSONByteSlice`, so the codec emits a 4-byte big-endian length prefix before the 20-byte id. We previously discarded it with `take(4)`. Now we read it as a `u32` and reject anything other than `NODE_ID_LEN` (20). A mismatched prefix would otherwise misalign the rest of the parse and could let the device display a `node_id` that differs from what was actually signed.

**`eth.test.ts` (`ForeignChainMustFail`) — tighten `signReq` typing**
Declared `signReq` with definite assignment (`let signReq!: Promise<unknown>`) instead of `Promise<unknown> | undefined`. It is always assigned in the `try` before any use, and the non-optional type keeps `expect(signReq).rejects` valid under strict TS.

## Not changed (false positive)

Copilot also flagged the `PIC` import in `add_auto_renewed_validator.rs` as unused. It is **not** unused — the `pic_str!` macro expands to reference `PIC`, so removing the import breaks the build (`cargo check` fails with "use of undeclared type `PIC`"). Left as-is.